### PR TITLE
add useful tools to closures

### DIFF
--- a/pkgs/nixos/base.nix
+++ b/pkgs/nixos/base.nix
@@ -123,6 +123,7 @@ in
         dtc
         ncdu
         nmap
+        nix-tree # https://github.com/utdemir/nix-tree
     ];
 
     programs.bash.interactiveShellInit = ''eval "$(direnv hook bash)"'';

--- a/pkgs/nixos/base.nix
+++ b/pkgs/nixos/base.nix
@@ -123,7 +123,8 @@ in
         dtc
         ncdu
         nmap
-        nix-tree # https://github.com/utdemir/nix-tree
+        # https://github.com/utdemir/nix-tree
+        (writeShellScriptBin "nix-deps" ''nix-build $@ --no-out-link | xargs -o ${nix-tree}/bin/nix-tree'')
     ];
 
     programs.bash.interactiveShellInit = ''eval "$(direnv hook bash)"'';

--- a/pkgs/nixos/base.nix
+++ b/pkgs/nixos/base.nix
@@ -150,7 +150,7 @@ in
         createHome = true;
         description = "Andrew Torgesen";
         group = "dev";
-        extraGroups = [ "users" "wheel" "networkmanager" "dialout" "video" "docker" "systemd-journal" ];
+        extraGroups = [ "users" "wheel" "networkmanager" "dialout" "video" "docker" "systemd-journal" "wireshark" ];
         subUidRanges = [ { count = 1; startUid = 1000; } { count = 65536; startUid = 100000; } ];
         subGidRanges = [ { count = 1; startGid = 100; } { count = 65536; startGid = 100000; } ];
         hashedPassword = "$6$0fv.6VfJi8qfOLtZ$nJ9OeiLzDenXaogPJl1bIe6ipx4KTnsyPExB.9sZk/dEXfFv34PtRRxZf28RKwrpcg5bgmee6QiQFGQQhv4rS/";
@@ -159,6 +159,8 @@ in
         ];
     };
     users.mutableUsers = true;
+
+    programs.wireshark.enable = true;
 
     home-manager.users.andrew = {
         programs.home-manager.enable = true;

--- a/pkgs/nixos/personal/software-configuration.nix
+++ b/pkgs/nixos/personal/software-configuration.nix
@@ -135,6 +135,7 @@ with import ../dependencies.nix { inherit config; };
             libreoffice-qt
             alacritty
             nixos-generators
+            wireshark
             ## unstable
             unstable.google-chrome
             unstable.slack

--- a/pkgs/nixos/personal/software-configuration.nix
+++ b/pkgs/nixos/personal/software-configuration.nix
@@ -57,6 +57,8 @@ with import ../dependencies.nix { inherit config; };
     nixpkgs.config.pulseaudio = true;
 
     services.udev.packages = [ pkgs.dolphinEmu ];
+    
+    programs.wireshark.enable = true;
 
     home-manager.users.andrew = {
         # nixpkgs/pkgs/data/themes

--- a/pkgs/nixos/personal/software-configuration.nix
+++ b/pkgs/nixos/personal/software-configuration.nix
@@ -57,8 +57,6 @@ with import ../dependencies.nix { inherit config; };
     nixpkgs.config.pulseaudio = true;
 
     services.udev.packages = [ pkgs.dolphinEmu ];
-    
-    programs.wireshark.enable = true;
 
     home-manager.users.andrew = {
         # nixpkgs/pkgs/data/themes
@@ -135,7 +133,6 @@ with import ../dependencies.nix { inherit config; };
             libreoffice-qt
             alacritty
             nixos-generators
-            wireshark
             ## unstable
             unstable.google-chrome
             unstable.slack


### PR DESCRIPTION
Is the `wireshark` cli tool available on a terminal-only machine in the current setup?

If so, consider moving this to base.nix.

Should probably add convenience scripts to wrap around `nix-tree`.