### PR TITLE
Fix OSCD git workflow and version increments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Tag Major Release
       run: |
+        git config user.name "Deploy from CI"
+        git config user.email ""
         git checkout master
         python scripts/increment_anix.py major
         git add .
@@ -25,6 +27,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Tag Minor Release
       run: |
+        git config user.name "Deploy from CI"
+        git config user.email ""
         git checkout master
         python scripts/increment_anix.py minor
         git add .
@@ -38,6 +42,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Tag Patch Release
       run: |
+        git config user.name "Deploy from CI"
+        git config user.email ""
         git checkout master
         python scripts/increment_anix.py patch
         git add .

--- a/scripts/increment_anix.py
+++ b/scripts/increment_anix.py
@@ -9,6 +9,8 @@ def increment_version(idx):
         anixvers = anixversfile.read()
     anixvers_split = anixvers.split(".")
     anixvers_split[idx] = str(int(anixvers_split[idx]) + 1)
+    for i in range(idx + 1, 3):
+        anixvers_split[i] = "0"
     with open(ANIXVERSFILE, "w") as anixversfile:
         anixversfile.write(".".join(anixvers_split))
 


### PR DESCRIPTION
Marked as a major release because the previous nixpkgs 23.05 reference was incorrect in the flake.