### PR TITLE
[notion] preserve nested sub-bullets when moving blocks

### DIFF
--- a/changes/pr-488.md
+++ b/changes/pr-488.md
@@ -1,0 +1,1 @@
+[notion] preserve nested sub-bullets when moving blocks

--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     "notion-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1775695868,
-        "narHash": "sha256-+WHhd2CYJSKsC+J10pjz2JzBXlhaM4jVPYGVn5JBfFU=",
+        "lastModified": 1776107009,
+        "narHash": "sha256-PxWbxt9LxMzsQrwK9j/r7JFInZvDpBPBzu9Pj+XgX6Y=",
         "owner": "goromal",
         "repo": "notion-tools",
-        "rev": "1e4652a0daec17ef801d0228a25be92a0bfaa59f",
+        "rev": "46b8e8eca2fca2703b6d34c8443e77e42b64f093",
         "type": "github"
       },
       "original": {

--- a/pkgs/modules/notion-mcp/notion-mcp-server.py
+++ b/pkgs/modules/notion-mcp/notion-mcp-server.py
@@ -139,13 +139,20 @@ class NotionClient:
         result = self._request("POST", "/pages", data)
         return result["id"]
 
-    def move_block(self, block_id: str, dest_page_id: str) -> None:
-        block = self._request("GET", f"/blocks/{block_id}")
+    def _build_block_with_children(self, block: dict) -> dict:
+        """Recursively build a block payload including any nested children."""
         btype = block["type"]
         bdata = dict(block[btype])
         if "rich_text" in bdata:
             bdata["rich_text"] = self._safe_rich_text(bdata["rich_text"])
-        new_block = {"object": "block", "type": btype, btype: bdata}
+        if block.get("has_children"):
+            children = self._get_block_children(block["id"])
+            bdata["children"] = [self._build_block_with_children(c) for c in children]
+        return {"object": "block", "type": btype, btype: bdata}
+
+    def move_block(self, block_id: str, dest_page_id: str) -> None:
+        block = self._request("GET", f"/blocks/{block_id}")
+        new_block = self._build_block_with_children(block)
         self._request("PATCH", f"/blocks/{dest_page_id}/children", {"children": [new_block]})
         self._request("DELETE", f"/blocks/{block_id}")
 


### PR DESCRIPTION
Update notion-mcp-server to recursively fetch and embed child blocks before deleting the source, matching the fix in notion-tools. Bump notion-tools flake input to 46b8e8e.