### PR TITLE
Add rcrsync to tasks_ui service PATH

### DIFF
--- a/changes/pr-514.md
+++ b/changes/pr-514.md
@@ -1,0 +1,1 @@
+[ATS] Add rcrsync to tasks_ui service PATH

--- a/pkgs/nixos/pc-base.nix
+++ b/pkgs/nixos/pc-base.nix
@@ -530,6 +530,7 @@ in
 
     services.tasks_ui = {
       enable = cfg.isATS;
+      rcrsync = machine-rcrsync;
     };
 
     environment.gnome = lib.mkIf (cfg.machineType == "x86_linux" && cfg.graphical) {

--- a/pkgs/python-packages/flasks/tasks_ui/module.nix
+++ b/pkgs/python-packages/flasks/tasks_ui/module.nix
@@ -52,7 +52,9 @@ in
       serviceConfig = {
         Type = "simple";
         ExecStart = "${cfg.package}/bin/tasks_ui --port ${builtins.toString cfg.port} --subdomain ${cfg.subdomain}";
-        Environment = lib.mkIf (cfg.rcrsync != null) "PATH=${cfg.rcrsync}/bin:/run/current-system/sw/bin:/usr/bin";
+        Environment = lib.mkIf (
+          cfg.rcrsync != null
+        ) "PATH=${cfg.rcrsync}/bin:/run/current-system/sw/bin:/usr/bin";
         ReadWritePaths = [ "/" ];
         WorkingDirectory = globalCfg.homeDir;
         Restart = "always";

--- a/pkgs/python-packages/flasks/tasks_ui/module.nix
+++ b/pkgs/python-packages/flasks/tasks_ui/module.nix
@@ -27,6 +27,11 @@ in
       description = "Subdomain path for reverse proxy";
       default = "/tasks";
     };
+    rcrsync = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      description = "The rcrsync package to add to the service PATH";
+      default = null;
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -47,6 +52,7 @@ in
       serviceConfig = {
         Type = "simple";
         ExecStart = "${cfg.package}/bin/tasks_ui --port ${builtins.toString cfg.port} --subdomain ${cfg.subdomain}";
+        Environment = lib.mkIf (cfg.rcrsync != null) "PATH=${cfg.rcrsync}/bin:/run/current-system/sw/bin:/usr/bin";
         ReadWritePaths = [ "/" ];
         WorkingDirectory = globalCfg.homeDir;
         Restart = "always";


### PR DESCRIPTION
## Summary
- Adds an `rcrsync` option to the `tasks_ui` NixOS module so a configured rcrsync package can be injected into the service's PATH
- Wires `machine-rcrsync` (already defined in `pc-base.nix`) into the `tasks_ui` service via the new option
- Fixes the silent failure when saving the spec CSV — `subprocess.run(['rcrsync', 'override', 'configs'])` was failing because rcrsync wasn't on the systemd service's PATH

## Test plan
- [x] Deployed locally with `anix-upgrade --local` — service restarted successfully
- [x] Verified `rcrsync` appears in `systemctl show tasks_ui.service --property=Environment`
- [x] Manually save spec CSV via the tasks UI and confirm cloud sync succeeds without warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)