### PR TITLE
Add manually triggered NixOS profile diff CI job

### DIFF
--- a/.github/workflows/nixos-profile-diff.yml
+++ b/.github/workflows/nixos-profile-diff.yml
@@ -1,0 +1,99 @@
+name: NixOS Profile Diff
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to post diff comment on (leave empty to only log)'
+        required: false
+        default: ''
+
+env:
+  NIXOS_VERSION: 25.11
+
+jobs:
+  diff:
+    name: Compare Profile Closures
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      # Checkout the triggered ref (PR branch) into ./pr
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          path: pr
+
+      # Find the merge-base of the PR branch against master
+      - name: Resolve base SHA
+        id: refs
+        run: |
+          cd pr
+          BASE_SHA=$(git merge-base HEAD origin/master)
+          echo "base_sha=$BASE_SHA"      >> $GITHUB_OUTPUT
+          echo "pr_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      # Checkout the merge-base into ./base
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.refs.outputs.base_sha }}
+          path: base
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-${{ env.NIXOS_VERSION }}
+          extra_nix_config: |
+            extra-platforms = aarch64-linux
+
+      - name: Run profile diff
+        run: |
+          echo "Base: ${{ steps.refs.outputs.base_sha }}"
+          echo "PR:   ${{ steps.refs.outputs.pr_sha }}"
+          python pr/scripts/nixos_profile_diff.py ./base ./pr /tmp/diff-report.md
+
+      - name: Show report
+        run: cat /tmp/diff-report.md
+
+      - name: Append commit context to report
+        run: |
+          echo "" >> /tmp/diff-report.md
+          echo "---" >> /tmp/diff-report.md
+          echo "*PR \`${{ steps.refs.outputs.pr_sha }}\` vs base \`${{ steps.refs.outputs.base_sha }}\`*" >> /tmp/diff-report.md
+
+      - name: Post comment on PR
+        if: ${{ inputs.pr_number != '' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/diff-report.md', 'utf8');
+            const prNumber = parseInt('${{ inputs.pr_number }}');
+
+            // Remove any previous diff comments from this workflow
+            const existing = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            for (const c of existing.data) {
+              if (c.body.startsWith('## NixOS Profile Diff')) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body,
+            });

--- a/docs/raw/README.md
+++ b/docs/raw/README.md
@@ -67,6 +67,16 @@ bash scripts/check_machines.sh
 
 *Automatically run as part of CI pipeline.*
 
+## NixOS Profile Diff
+
+To compare NixOS profile closures between a PR branch and its merge base, trigger the **NixOS Profile Diff** workflow manually from the GitHub Actions UI:
+
+1. Go to **Actions → NixOS Profile Diff → Run workflow**
+2. Select the PR branch from the branch dropdown
+3. Optionally enter the PR number in the `pr_number` field to have the diff posted as a comment (replacing any previous one); leave blank to only log the output
+
+The job evaluates each known machine configuration (`personal-*`, `ats-*`, `jetpack-*`) on both the PR branch and the merge-base, reports any package additions or removals per profile, and flags new or deleted profiles.
+
 ## SITL
 
 Some commands to spin up SITL environments:

--- a/scripts/nixos_profile_diff.py
+++ b/scripts/nixos_profile_diff.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Compare NixOS profile closures between two repo checkouts.
+
+Usage: nixos_profile_diff.py <base_dir> <pr_dir> [output_file]
+  base_dir    Path to base branch checkout
+  pr_dir      Path to PR branch checkout
+  output_file Path to write markdown report (default: stdout)
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+KNOWN_CONFIGURATIONS = [
+    "jetpack-orin-nx",
+    "personal-inspiron",
+    "personal-panasonic",
+    "personal-dell",
+    "ats-alderlake",
+    "ats-pi",
+]
+
+NIX_ENV = {
+    **os.environ,
+    "NIXPKGS_ALLOW_UNFREE": "1",
+    "NIXPKGS_ALLOW_INSECURE": "1",
+    "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM": "1",
+}
+
+
+def patch_local_build(repo_dir: str, enable: bool) -> None:
+    deps = Path(repo_dir) / "pkgs/nixos/dependencies.nix"
+    text = deps.read_text()
+    if enable:
+        text = text.replace("local-build = false;", "local-build = true;")
+    else:
+        text = text.replace("local-build = true;", "local-build = false;")
+    deps.write_text(text)
+
+
+def instantiate(repo_dir: str, config: str) -> str | None:
+    """Return .drv path, 'ERROR', or None if config file absent."""
+    config_path = Path(repo_dir) / f"pkgs/nixos/configurations/{config}.nix"
+    if not config_path.exists():
+        return None
+    result = subprocess.run(
+        [
+            "nix-instantiate",
+            "<nixpkgs/nixos>",
+            "-A", "config.system.build.toplevel",
+            "-I", f"nixos-config={config_path}",
+            "--no-gc-warning",
+        ],
+        capture_output=True,
+        text=True,
+        env=NIX_ENV,
+    )
+    if result.returncode != 0:
+        return "ERROR"
+    return result.stdout.strip().splitlines()[-1]  # last line is the .drv path
+
+
+def closure_names(drv_path: str) -> set[str]:
+    """Return set of package name-version strings from the derivation closure."""
+    result = subprocess.run(
+        ["nix-store", "--query", "--requisites", drv_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return set()
+    names = set()
+    for line in result.stdout.strip().splitlines():
+        # /nix/store/<hash>-<name> -> <name>
+        m = re.match(r"/nix/store/[a-z0-9]{32}-(.+)", line)
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+def fmt_pkg_list(items: set[str], marker: str) -> str:
+    return "\n".join(f"  {marker} `{item}`" for item in sorted(items))
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+
+    base_dir = sys.argv[1]
+    pr_dir = sys.argv[2]
+    output_file = sys.argv[3] if len(sys.argv) > 3 else None
+
+    for d in (base_dir, pr_dir):
+        patch_local_build(d, True)
+
+    try:
+        base_configs = {p.stem for p in (Path(base_dir) / "pkgs/nixos/configurations").glob("*.nix")}
+        pr_configs   = {p.stem for p in (Path(pr_dir)   / "pkgs/nixos/configurations").glob("*.nix")}
+        all_configs  = sorted((base_configs | pr_configs) & set(KNOWN_CONFIGURATIONS))
+
+        # (config, status, added_set | None, removed_set | None)
+        results = []
+
+        for config in all_configs:
+            in_base = config in base_configs
+            in_pr   = config in pr_configs
+
+            if not in_base:
+                results.append((config, "new", None, None))
+                continue
+            if not in_pr:
+                results.append((config, "deleted", None, None))
+                continue
+
+            print(f"  Evaluating {config}...", flush=True)
+            base_drv = instantiate(base_dir, config)
+            pr_drv   = instantiate(pr_dir,   config)
+
+            if base_drv == "ERROR" and pr_drv == "ERROR":
+                results.append((config, "both_error", None, None))
+            elif base_drv == "ERROR":
+                results.append((config, "new", None, None))
+            elif pr_drv == "ERROR":
+                results.append((config, "deleted", None, None))
+            elif base_drv == pr_drv:
+                results.append((config, "unchanged", None, None))
+            else:
+                print(f"    {config}: derivation changed, computing closure diff...", flush=True)
+                base_names = closure_names(base_drv)
+                pr_names   = closure_names(pr_drv)
+                added   = pr_names   - base_names
+                removed = base_names - pr_names
+                results.append((config, "changed", added, removed))
+
+        # ── Build report ──────────────────────────────────────────────────────
+        lines = ["## NixOS Profile Diff", ""]
+
+        # Summary table
+        lines += ["| Profile | Status |", "|---------|--------|"]
+        for config, status, added, removed in results:
+            if status == "unchanged":
+                badge = "✅ No delta"
+            elif status == "new":
+                badge = "🆕 New profile"
+            elif status == "deleted":
+                badge = "🗑️ Deleted"
+            elif status == "both_error":
+                badge = "❌ Eval error on both branches"
+            else:
+                badge = f"⚠️ +{len(added)} / -{len(removed)} packages"
+            lines.append(f"| `{config}` | {badge} |")
+
+        # Detail blocks for changed profiles
+        for config, status, added, removed in results:
+            if status != "changed":
+                continue
+            summary = f"`{config}` — +{len(added)} / -{len(removed)} packages"
+            lines += [f"\n<details><summary>{summary}</summary>", ""]
+            if added:
+                lines.append("**Added:**")
+                lines.append(fmt_pkg_list(added, "+"))
+            if removed:
+                lines.append("\n**Removed:**")
+                lines.append(fmt_pkg_list(removed, "-"))
+            lines.append("\n</details>")
+
+        report = "\n".join(lines) + "\n"
+
+        if output_file:
+            Path(output_file).write_text(report)
+        else:
+            print(report)
+
+    finally:
+        for d in (base_dir, pr_dir):
+            patch_local_build(d, False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a workflow_dispatch GitHub Actions job that compares NixOS profile closures between a PR branch and its merge-base against master. For each known machine configuration it runs nix-instantiate on both checkouts, compares the resulting .drv paths, and computes a full closure diff (via nix-store --query --requisites) only when a change is detected. Results are posted as a PR comment when a pr_number input is supplied.