### PR TITLE
feat(tasks_ui): add day-of-week support for weekly recurring tasks

### DIFF
--- a/changes/pr-548.md
+++ b/changes/pr-548.md
@@ -1,0 +1,1 @@
+feat(tasks_ui): add day-of-week support for weekly recurring tasks

--- a/flake.lock
+++ b/flake.lock
@@ -966,16 +966,15 @@
     "task-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1781323225,
+        "lastModified": 1781406286,
         "narHash": "sha256-Hshdgk7lR6X4FfNAeUJstdYStVQuxJfF9De8j0cz7cs=",
         "owner": "goromal",
         "repo": "task-tools",
-        "rev": "822b65ef3903bbcf5e169d0a29d9a19e6eed9f6c",
+        "rev": "0c7b7a9b632bd8f25b6a522022e7f1167f60aa73",
         "type": "github"
       },
       "original": {
         "owner": "goromal",
-        "ref": "dev/days-tasks",
         "repo": "task-tools",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -966,15 +966,16 @@
     "task-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1767334634,
-        "narHash": "sha256-zYvvI2k/rDuF+9uvQFCsQQzMPmhnXLZO6nLPlgeUYFc=",
+        "lastModified": 1781323225,
+        "narHash": "sha256-Hshdgk7lR6X4FfNAeUJstdYStVQuxJfF9De8j0cz7cs=",
         "owner": "goromal",
         "repo": "task-tools",
-        "rev": "0c08127eb7111da929ce5514b4b8411bc46f250b",
+        "rev": "822b65ef3903bbcf5e169d0a29d9a19e6eed9f6c",
         "type": "github"
       },
       "original": {
         "owner": "goromal",
+        "ref": "dev/days-tasks",
         "repo": "task-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
     symforce.url = "github:symforce-org/symforce?ref=refs/tags/v0.9.0";
     symforce.flake = false;
 
-    task-tools.url = "github:goromal/task-tools/dev/days-tasks";
+    task-tools.url = "github:goromal/task-tools";
     task-tools.flake = false;
 
     trafficsim.url = "git+https://gist.github.com/c37629235750b65b9d0ec0e17456ee96";

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
     symforce.url = "github:symforce-org/symforce?ref=refs/tags/v0.9.0";
     symforce.flake = false;
 
-    task-tools.url = "github:goromal/task-tools";
+    task-tools.url = "github:goromal/task-tools/dev/days-tasks";
     task-tools.flake = false;
 
     trafficsim.url = "git+https://gist.github.com/c37629235750b65b9d0ec0e17456ee96";

--- a/pkgs/python-packages/flasks/orchestrator_ui/orchestrator_ui.py
+++ b/pkgs/python-packages/flasks/orchestrator_ui/orchestrator_ui.py
@@ -65,8 +65,9 @@ def get_service_info(service):
 @bp.route('/')
 def index():
     statuses = {svc: get_service_state(svc) for svc in services}
+    orch_state = get_service_state('orchestratord')
     return render_template('main.html', services=services, statuses=statuses,
-                           subdomain=args.subdomain)
+                           orch_state=orch_state, subdomain=args.subdomain)
 
 
 @bp.route('/status/<service>')
@@ -102,52 +103,6 @@ def restart(service):
             yield "data: [Restart successful]\n\n"
         else:
             yield f"data: [Restart failed with exit code {proc.returncode}]\n\n"
-        yield "data: [DONE]\n\n"
-
-    return Response(stream_with_context(generate()), mimetype='text/event-stream')
-
-
-@bp.route('/stop/<service>', methods=['POST'])
-def stop(service):
-    if service not in services:
-        return jsonify({'error': 'Invalid service'}), 400
-
-    def generate():
-        proc = subprocess.Popen(
-            ['systemctl', 'stop', service],
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            text=True
-        )
-        for line in proc.stdout:
-            yield f"data: {line.rstrip()}\n\n"
-        proc.wait()
-        if proc.returncode == 0:
-            yield "data: [Stop successful]\n\n"
-        else:
-            yield f"data: [Stop failed with exit code {proc.returncode}]\n\n"
-        yield "data: [DONE]\n\n"
-
-    return Response(stream_with_context(generate()), mimetype='text/event-stream')
-
-
-@bp.route('/start/<service>', methods=['POST'])
-def start(service):
-    if service not in services:
-        return jsonify({'error': 'Invalid service'}), 400
-
-    def generate():
-        proc = subprocess.Popen(
-            ['systemctl', 'start', service],
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            text=True
-        )
-        for line in proc.stdout:
-            yield f"data: {line.rstrip()}\n\n"
-        proc.wait()
-        if proc.returncode == 0:
-            yield "data: [Start successful]\n\n"
-        else:
-            yield f"data: [Start failed with exit code {proc.returncode}]\n\n"
         yield "data: [DONE]\n\n"
 
     return Response(stream_with_context(generate()), mimetype='text/event-stream')
@@ -195,6 +150,51 @@ def job_detail(job_id):
         })
     except Exception as e:
         return jsonify({'error': str(e)}), 503
+
+
+@bp.route('/status-orchestratord')
+def status_orchestratord():
+    return jsonify({'state': get_service_state('orchestratord')})
+
+
+@bp.route('/stop-orchestratord', methods=['POST'])
+def stop_orchestratord():
+    def generate():
+        proc = subprocess.Popen(
+            ['systemctl', 'stop', 'orchestratord'],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True
+        )
+        for line in proc.stdout:
+            yield f"data: {line.rstrip()}\n\n"
+        proc.wait()
+        if proc.returncode == 0:
+            yield "data: [Stop successful]\n\n"
+        else:
+            yield f"data: [Stop failed with exit code {proc.returncode}]\n\n"
+        yield "data: [DONE]\n\n"
+
+    return Response(stream_with_context(generate()), mimetype='text/event-stream')
+
+
+@bp.route('/start-orchestratord', methods=['POST'])
+def start_orchestratord():
+    def generate():
+        proc = subprocess.Popen(
+            ['systemctl', 'start', 'orchestratord'],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True
+        )
+        for line in proc.stdout:
+            yield f"data: {line.rstrip()}\n\n"
+        proc.wait()
+        if proc.returncode == 0:
+            yield "data: [Start successful]\n\n"
+        else:
+            yield f"data: [Start failed with exit code {proc.returncode}]\n\n"
+        yield "data: [DONE]\n\n"
+
+    return Response(stream_with_context(generate()), mimetype='text/event-stream')
 
 
 @bp.route('/restart-orchestratord', methods=['POST'])

--- a/pkgs/python-packages/flasks/orchestrator_ui/orchestrator_ui.py
+++ b/pkgs/python-packages/flasks/orchestrator_ui/orchestrator_ui.py
@@ -107,6 +107,52 @@ def restart(service):
     return Response(stream_with_context(generate()), mimetype='text/event-stream')
 
 
+@bp.route('/stop/<service>', methods=['POST'])
+def stop(service):
+    if service not in services:
+        return jsonify({'error': 'Invalid service'}), 400
+
+    def generate():
+        proc = subprocess.Popen(
+            ['systemctl', 'stop', service],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True
+        )
+        for line in proc.stdout:
+            yield f"data: {line.rstrip()}\n\n"
+        proc.wait()
+        if proc.returncode == 0:
+            yield "data: [Stop successful]\n\n"
+        else:
+            yield f"data: [Stop failed with exit code {proc.returncode}]\n\n"
+        yield "data: [DONE]\n\n"
+
+    return Response(stream_with_context(generate()), mimetype='text/event-stream')
+
+
+@bp.route('/start/<service>', methods=['POST'])
+def start(service):
+    if service not in services:
+        return jsonify({'error': 'Invalid service'}), 400
+
+    def generate():
+        proc = subprocess.Popen(
+            ['systemctl', 'start', service],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True
+        )
+        for line in proc.stdout:
+            yield f"data: {line.rstrip()}\n\n"
+        proc.wait()
+        if proc.returncode == 0:
+            yield "data: [Start successful]\n\n"
+        else:
+            yield f"data: [Start failed with exit code {proc.returncode}]\n\n"
+        yield "data: [DONE]\n\n"
+
+    return Response(stream_with_context(generate()), mimetype='text/event-stream')
+
+
 @bp.route('/jobs/summary')
 def jobs_summary():
     try:

--- a/pkgs/python-packages/flasks/orchestrator_ui/templates/main.html
+++ b/pkgs/python-packages/flasks/orchestrator_ui/templates/main.html
@@ -77,9 +77,6 @@
               <button class="btn btn-sm btn-primary"
                 onclick="triggerRestart('{{ svc }}', {{ loop.index }})"
                 id="btn-{{ loop.index }}">Restart</button>
-              <button class="btn btn-sm {% if state == 'active' %}btn-outline-danger{% else %}btn-outline-success{% endif %}"
-                onclick="triggerToggle('{{ svc }}', {{ loop.index }})"
-                id="toggle-{{ loop.index }}">{% if state == 'active' %}Stop{% else %}Start{% endif %}</button>
               <button class="btn btn-sm btn-outline-secondary"
                 onclick="refreshStatus('{{ svc }}', {{ loop.index }})">Refresh</button>
             </div>
@@ -95,7 +92,9 @@
   <div class="section-header">
     <h5 class="mb-0">Job Monitor</h5>
     <button class="btn btn-sm btn-outline-secondary" onclick="refreshJobs()">Refresh</button>
-    <button class="btn btn-sm btn-danger ms-auto" id="orch-restart-btn"
+    <button class="btn btn-sm {% if orch_state == 'active' %}btn-outline-danger{% else %}btn-outline-success{% endif %} ms-auto"
+      id="orch-toggle-btn" onclick="toggleOrchestratord()">{% if orch_state == 'active' %}Stop{% else %}Start{% endif %} orchestratord</button>
+    <button class="btn btn-sm btn-danger" id="orch-restart-btn"
       onclick="restartOrchestratord()">Restart orchestratord</button>
   </div>
   <div id="orch-restart-log" class="orch-restart-log mb-3"></div>
@@ -137,43 +136,11 @@ function setBadge(idx, state) {
   else badge.classList.add('bg-warning', 'text-dark');
 }
 
-function setToggleBtn(idx, state) {
-  const btn = document.getElementById('toggle-' + idx);
-  if (!btn) return;
-  const isActive = state === 'active';
-  btn.textContent = isActive ? 'Stop' : 'Start';
-  btn.className = 'btn btn-sm ' + (isActive ? 'btn-outline-danger' : 'btn-outline-success');
-}
-
 function refreshStatus(service, idx) {
   fetch(subdomain + '/status/' + encodeURIComponent(service))
     .then(r => r.json())
-    .then(data => {
-      const state = data.state || 'unknown';
-      setBadge(idx, state);
-      setToggleBtn(idx, state);
-    })
-    .catch(() => {
-      setBadge(idx, 'unknown');
-      setToggleBtn(idx, 'unknown');
-    });
-}
-
-function triggerToggle(service, idx) {
-  const toggleBtn = document.getElementById('toggle-' + idx);
-  const log = document.getElementById('log-' + idx);
-  const currentText = toggleBtn.textContent.trim();
-  const isStopping = currentText === 'Stop';
-  const action = isStopping ? 'stop' : 'start';
-  const label = isStopping ? 'Stopping' : 'Starting';
-  toggleBtn.disabled = true;
-  toggleBtn.innerHTML = '<span class="spinner-border" role="status"></span> ' + label + '...';
-  log.textContent = '';
-  log.classList.add('visible');
-  streamPost(subdomain + '/' + action + '/' + encodeURIComponent(service), log, () => {
-    toggleBtn.disabled = false;
-    refreshStatus(service, idx);
-  });
+    .then(data => setBadge(idx, data.state || 'unknown'))
+    .catch(() => setBadge(idx, 'unknown'));
 }
 
 function triggerRestart(service, idx) {
@@ -223,7 +190,35 @@ function streamPost(url, logEl, onDone) {
     });
 }
 
-// ── orchestratord restart ───────────────────────────────────────────────────
+// ── orchestratord controls ──────────────────────────────────────────────────
+
+function refreshOrchState() {
+  fetch(subdomain + '/status-orchestratord')
+    .then(r => r.json())
+    .then(data => {
+      const btn = document.getElementById('orch-toggle-btn');
+      const isActive = (data.state || 'unknown') === 'active';
+      btn.textContent = (isActive ? 'Stop' : 'Start') + ' orchestratord';
+      btn.className = 'btn btn-sm ' + (isActive ? 'btn-outline-danger' : 'btn-outline-success') + ' ms-auto';
+    });
+}
+
+function toggleOrchestratord() {
+  const btn = document.getElementById('orch-toggle-btn');
+  const log = document.getElementById('orch-restart-log');
+  const isStopping = btn.textContent.trim().startsWith('Stop');
+  const endpoint = isStopping ? '/stop-orchestratord' : '/start-orchestratord';
+  const label = isStopping ? 'Stopping' : 'Starting';
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner-border" role="status"></span> ' + label + '...';
+  log.textContent = '';
+  log.classList.add('visible');
+  streamPost(subdomain + endpoint, log, () => {
+    btn.disabled = false;
+    refreshOrchState();
+    setTimeout(refreshJobs, 2000);
+  });
+}
 
 function restartOrchestratord() {
   const btn = document.getElementById('orch-restart-btn');

--- a/pkgs/python-packages/flasks/orchestrator_ui/templates/main.html
+++ b/pkgs/python-packages/flasks/orchestrator_ui/templates/main.html
@@ -77,6 +77,9 @@
               <button class="btn btn-sm btn-primary"
                 onclick="triggerRestart('{{ svc }}', {{ loop.index }})"
                 id="btn-{{ loop.index }}">Restart</button>
+              <button class="btn btn-sm {% if state == 'active' %}btn-outline-danger{% else %}btn-outline-success{% endif %}"
+                onclick="triggerToggle('{{ svc }}', {{ loop.index }})"
+                id="toggle-{{ loop.index }}">{% if state == 'active' %}Stop{% else %}Start{% endif %}</button>
               <button class="btn btn-sm btn-outline-secondary"
                 onclick="refreshStatus('{{ svc }}', {{ loop.index }})">Refresh</button>
             </div>
@@ -134,11 +137,43 @@ function setBadge(idx, state) {
   else badge.classList.add('bg-warning', 'text-dark');
 }
 
+function setToggleBtn(idx, state) {
+  const btn = document.getElementById('toggle-' + idx);
+  if (!btn) return;
+  const isActive = state === 'active';
+  btn.textContent = isActive ? 'Stop' : 'Start';
+  btn.className = 'btn btn-sm ' + (isActive ? 'btn-outline-danger' : 'btn-outline-success');
+}
+
 function refreshStatus(service, idx) {
   fetch(subdomain + '/status/' + encodeURIComponent(service))
     .then(r => r.json())
-    .then(data => setBadge(idx, data.state || 'unknown'))
-    .catch(() => setBadge(idx, 'unknown'));
+    .then(data => {
+      const state = data.state || 'unknown';
+      setBadge(idx, state);
+      setToggleBtn(idx, state);
+    })
+    .catch(() => {
+      setBadge(idx, 'unknown');
+      setToggleBtn(idx, 'unknown');
+    });
+}
+
+function triggerToggle(service, idx) {
+  const toggleBtn = document.getElementById('toggle-' + idx);
+  const log = document.getElementById('log-' + idx);
+  const currentText = toggleBtn.textContent.trim();
+  const isStopping = currentText === 'Stop';
+  const action = isStopping ? 'stop' : 'start';
+  const label = isStopping ? 'Stopping' : 'Starting';
+  toggleBtn.disabled = true;
+  toggleBtn.innerHTML = '<span class="spinner-border" role="status"></span> ' + label + '...';
+  log.textContent = '';
+  log.classList.add('visible');
+  streamPost(subdomain + '/' + action + '/' + encodeURIComponent(service), log, () => {
+    toggleBtn.disabled = false;
+    refreshStatus(service, idx);
+  });
 }
 
 function triggerRestart(service, idx) {

--- a/pkgs/python-packages/flasks/tasks_ui/tasks_ui.py
+++ b/pkgs/python-packages/flasks/tasks_ui/tasks_ui.py
@@ -5,6 +5,10 @@ import os
 import subprocess
 
 from flask import Flask, Blueprint, request, render_template, Response, stream_with_context
+# parse_interval and _all_weeks_on_day are module-level helpers in task_tools.cli.
+# They are imported directly rather than from a shared utils module — update this
+# import if those helpers are ever moved.
+from task_tools.cli import parse_interval, _all_weeks_on_day
 
 
 def _init_manager():
@@ -13,17 +17,6 @@ def _init_manager():
         return TaskManager(), None
     except Exception as e:
         return None, str(e)
-
-
-def _all_sundays(start, end):
-    result = []
-    current = start
-    while current.weekday() != 6:
-        current += datetime.timedelta(days=1)
-    while current <= end:
-        result.append(current)
-        current += datetime.timedelta(days=7)
-    return result
 
 
 def _first_sundays_of_month(start, end):
@@ -50,24 +43,17 @@ def _first_sundays_of_quarter(start, end):
 
 
 def _read_spec_csv(path):
-    daily, weekly, monthly, quarterly = [], [], [], []
+    items = []
     with open(path, 'r') as f:
         for line in f:
             parts = line.split('|', 2)
             if len(parts) < 2:
                 continue
-            rtype = parts[0].strip().lower()
+            rtype = parts[0].strip()
             title = parts[1].strip()
             desc = parts[2].strip() if len(parts) > 2 else ''
-            if rtype == 'd':
-                daily.append((title, desc))
-            elif rtype == 'w':
-                weekly.append((title, desc))
-            elif rtype == 'm':
-                monthly.append((title, desc))
-            elif rtype == 'q':
-                quarterly.append((title, desc))
-    return daily, weekly, monthly, quarterly
+            items.append((rtype, title, desc))
+    return items
 
 
 def create_app(subdomain='', manager=None, spec_csv=None):
@@ -136,16 +122,11 @@ def create_app(subdomain='', manager=None, spec_csv=None):
     @bp.route('/spec-csv', methods=['GET'])
     def spec_csv_get():
         try:
-            daily, weekly, monthly, quarterly = _read_spec_csv(_spec_csv)
+            items = _read_spec_csv(_spec_csv)
         except FileNotFoundError:
             return {'items': []}
-        items = (
-            [{'interval': 'd', 'title': t, 'desc': d} for t, d in daily] +
-            [{'interval': 'w', 'title': t, 'desc': d} for t, d in weekly] +
-            [{'interval': 'm', 'title': t, 'desc': d} for t, d in monthly] +
-            [{'interval': 'q', 'title': t, 'desc': d} for t, d in quarterly]
-        )
-        return {'items': items}
+        return {'items': [{'interval': rtype, 'title': title, 'desc': desc}
+                           for rtype, title, desc in items]}
 
     @bp.route('/spec-csv', methods=['POST'])
     def spec_csv_post():
@@ -203,11 +184,32 @@ def create_app(subdomain='', manager=None, spec_csv=None):
             end = start
 
         try:
-            daily, weekly, monthly, quarterly = _read_spec_csv(_spec_csv)
+            raw_items = _read_spec_csv(_spec_csv)
         except FileNotFoundError:
             return {'error': f'CSV not found: {_spec_csv}'}, 500
 
-        sundays = set(_all_sundays(start, end))
+        daily = []
+        weekly_by_day = {}
+        monthly = []
+        quarterly = []
+        for rtype, title, desc in raw_items:
+            try:
+                itype, weekday = parse_interval(rtype)
+            except ValueError as e:
+                return {'error': str(e)}, 400
+            if itype == 'd':
+                daily.append((title, desc))
+            elif itype == 'w':
+                weekly_by_day.setdefault(weekday, []).append((title, desc))
+            elif itype == 'm':
+                monthly.append((title, desc))
+            elif itype == 'q':
+                quarterly.append((title, desc))
+
+        week_dates_by_day = {
+            day: set(_all_weeks_on_day(start, end, day))
+            for day in weekly_by_day
+        }
         month_sundays = set(_first_sundays_of_month(start, end))
         quarter_sundays = set(_first_sundays_of_quarter(start, end))
 
@@ -216,8 +218,9 @@ def create_app(subdomain='', manager=None, spec_csv=None):
             while current <= end:
                 label = current.strftime('%Y-%m-%d')
                 due = list(daily)
-                if current in sundays:
-                    due += weekly
+                for day, specs in weekly_by_day.items():
+                    if current in week_dates_by_day[day]:
+                        due += specs
                 if current in month_sundays:
                     due += monthly
                 if current in quarter_sundays:

--- a/pkgs/python-packages/flasks/tasks_ui/templates/main.html
+++ b/pkgs/python-packages/flasks/tasks_ui/templates/main.html
@@ -77,6 +77,11 @@
       cursor: pointer; padding: 4px 8px; font-size: 14px; color: #888;
     }
     .csv-item-row .csv-delete:hover { background: #fee; color: #c00; }
+    .csv-item-row .csv-day {
+      width: 70px; flex-shrink: 0; padding: 6px 4px;
+      border: 1px solid #ccc; border-radius: 4px; font-size: 13px;
+    }
+    .csv-item-row .csv-day:disabled { visibility: hidden; }
     #csv-dirty-banner {
       background: #fffbe6; border: 1px solid #f0c040; color: #7a5c00;
       padding: 8px 14px; border-radius: 4px; margin-bottom: 12px; font-size: 14px;
@@ -399,6 +404,8 @@
 
     const INTERVAL_LABELS = {d: 'Daily', w: 'Weekly', m: 'Monthly', q: 'Quarterly'};
     const INTERVAL_ORDER = ['d', 'w', 'm', 'q'];
+    const DAY_OPTIONS = ['sun','mon','tue','wed','thu','fri','sat'];
+    const DAY_LABELS  = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
 
     function csvDeepCopy(items) {
       return items.map(i => ({interval: i.interval, title: i.title, desc: i.desc}));
@@ -420,8 +427,8 @@
       const groups = {};
       INTERVAL_ORDER.forEach(k => { groups[k] = []; });
       csvItems.forEach((item, idx) => {
-        const key = INTERVAL_ORDER.includes(item.interval) ? item.interval : 'w';
-        groups[key].push({item, idx});
+        const key = item.interval.split(':')[0];
+        if (groups[key]) groups[key].push({item, idx});
       });
 
       INTERVAL_ORDER.forEach(key => {
@@ -436,12 +443,15 @@
           const row = document.createElement('div');
           row.className = 'csv-item-row';
 
+          const baseInterval = item.interval.split(':')[0];
+          const dayPart = item.interval.includes(':') ? item.interval.split(':')[1] : (baseInterval === 'w' ? 'sun' : null);
+
           const sel = document.createElement('select');
           INTERVAL_ORDER.forEach(k => {
             const opt = document.createElement('option');
             opt.value = k;
             opt.textContent = INTERVAL_LABELS[k];
-            if (k === item.interval) opt.selected = true;
+            if (k === baseInterval) opt.selected = true;
             sel.appendChild(opt);
           });
           sel.addEventListener('change', () => {
@@ -449,6 +459,25 @@
             csvOnChange();
             csvRender();  // re-render to move item to new group
           });
+
+          const daySel = document.createElement('select');
+          daySel.className = 'csv-day';
+          DAY_OPTIONS.forEach((d, i) => {
+            const opt = document.createElement('option');
+            opt.value = d;
+            opt.textContent = DAY_LABELS[i];
+            if (d === dayPart) opt.selected = true;
+            daySel.appendChild(opt);
+          });
+          if (baseInterval === 'w') {
+            daySel.addEventListener('change', () => {
+              const val = daySel.value;
+              csvItems[idx].interval = (val === 'sun') ? 'w' : 'w:' + val;
+              csvOnChange();
+            });
+          } else {
+            daySel.disabled = true;
+          }
 
           const titleInput = document.createElement('input');
           titleInput.type = 'text';
@@ -480,6 +509,7 @@
           });
 
           row.appendChild(sel);
+          row.appendChild(daySel);
           row.appendChild(titleInput);
           row.appendChild(descInput);
           row.appendChild(delBtn);

--- a/pkgs/python-packages/flasks/tasks_ui/tests/test_tasks_ui.py
+++ b/pkgs/python-packages/flasks/tasks_ui/tests/test_tasks_ui.py
@@ -306,3 +306,64 @@ def test_spec_submit_idempotent_skips_existing(tmp_path):
         assert payloads[0]['status'] == 'ok'
         assert payloads[0]['tasks'] == []
         mock_mgr.putTask.assert_not_called()
+
+
+def test_spec_csv_get_returns_interval_with_day_suffix(tmp_path):
+    csv = tmp_path / 'tasks.csv'
+    csv.write_text('w:mon|Monday Task|notes\n')
+    app = make_app(spec_csv=str(csv))
+    with app.test_client() as client:
+        resp = client.get('/spec-csv')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['items'][0] == {'interval': 'w:mon', 'title': 'Monday Task', 'desc': 'notes'}
+
+
+def test_spec_submit_w_mon_spawns_on_monday(tmp_path):
+    csv = tmp_path / 'tasks.csv'
+    csv.write_text('w:mon|Monday Task|\n')
+    mock_mgr = MagicMock()
+    mock_mgr.getTasks.return_value = []
+    app = make_app(mock_manager=mock_mgr, spec_csv=str(csv))
+    with app.test_client() as client:
+        # 2026-06-01 is Monday; range Mon–Sun contains exactly one Monday
+        resp = client.post('/spec-submit',
+                           data=json.dumps({'start_date': '2026-06-01', 'end_date': '2026-06-07'}),
+                           content_type='application/json')
+        body = resp.get_data(as_text=True)
+        payloads = [json.loads(line[6:]) for line in body.splitlines()
+                    if line.startswith('data: ') and '"done"' not in line]
+        ok_payloads = [p for p in payloads if p['status'] == 'ok']
+        assert len(ok_payloads) == 1
+        assert ok_payloads[0]['date'] == '2026-06-01'
+        mock_mgr.putTask.assert_called_once()
+
+
+def test_spec_submit_w_mon_does_not_spawn_on_sunday(tmp_path):
+    csv = tmp_path / 'tasks.csv'
+    csv.write_text('w:mon|Monday Task|\n')
+    mock_mgr = MagicMock()
+    mock_mgr.getTasks.return_value = []
+    app = make_app(mock_manager=mock_mgr, spec_csv=str(csv))
+    with app.test_client() as client:
+        # 2026-07-05 is Sunday; no Monday in this 1-day range
+        resp = client.post('/spec-submit',
+                           data=json.dumps({'start_date': '2026-07-05', 'end_date': '2026-07-05'}),
+                           content_type='application/json')
+        body = resp.get_data(as_text=True)
+        payloads = [json.loads(line[6:]) for line in body.splitlines()
+                    if line.startswith('data: ') and '"done"' not in line]
+        non_skip = [p for p in payloads if p['status'] != 'skip']
+        assert len(non_skip) == 0
+
+
+def test_spec_submit_invalid_day_token_returns_400(tmp_path):
+    csv = tmp_path / 'tasks.csv'
+    csv.write_text('w:xyz|Bad Task|\n')
+    app = make_app(spec_csv=str(csv))
+    with app.test_client() as client:
+        resp = client.post('/spec-submit',
+                           data=json.dumps({'start_date': '2026-06-01', 'end_date': '2026-06-07'}),
+                           content_type='application/json')
+        assert resp.status_code == 400
+        assert 'error' in resp.get_json()


### PR DESCRIPTION
## Summary

- Updates `tasks_ui.py` to import `parse_interval`/`_all_weeks_on_day` from `task_tools.cli`, flattens `_read_spec_csv` to return raw `(token, title, desc)` tuples, and updates `/spec-submit` to group weekly specs by weekday (supports `w:mon`, `w:fri`, etc.)
- Adds Day `<select>` dropdown column in `main.html` CSV editor — enabled only for Weekly rows, serializes to `w:mon` / `w` (Sun)
- Removes `_all_sundays` function; backward-compatible: plain `w` still spawns on Sundays
- Points `task-tools` flake input to `dev/days-tasks` branch pending task-tools PR merge
- https://github.com/goromal/task-tools/pull/24

## Test Plan

- [x] `GET /spec-csv` returns `{'interval': 'w:mon', ...}` for a `w:mon` CSV row
- [x] `POST /spec-submit` with `w:mon` CSV spawns task only on Mondays in range
- [x] `POST /spec-submit` with `w:xyz` CSV returns HTTP 400
- [x] Day dropdown visible in all CSV editor rows; enabled only for Weekly interval
- [x] Selecting Mon stores `w:mon`; selecting Sun stores `w`; `w:fri` round-trips correctly
- [x] All 26 tests in `tasks_ui/tests/test_tasks_ui.py` pass
