### PR TITLE
anix-upgrade-ui: fix browser freeze on large build logs; add log download

### DIFF
--- a/changes/pr-552.md
+++ b/changes/pr-552.md
@@ -1,0 +1,1 @@
+anix-upgrade-ui: fix browser freeze on large build logs; add log download

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "anixdata": {
       "flake": false,
       "locked": {
-        "lastModified": 1781240032,
-        "narHash": "sha256-0/6LBHd1Qtraw9kU2RaK5tQHd4KetnRjYip1L/LSfyE=",
+        "lastModified": 1781675895,
+        "narHash": "sha256-B8BsxCei00RXNYbl7KGtvD40XlDgSz9cj9UFboS2mYM=",
         "owner": "goromal",
         "repo": "anixdata",
-        "rev": "c937a45fdb08d5b6f07f893be4697d5916bc5100",
+        "rev": "6d14d3dc1d3460ab3abbe053d706454842f06321",
         "type": "github"
       },
       "original": {

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 
-from flask import Blueprint, Flask, Response, jsonify, render_template, request
+from flask import Blueprint, Flask, Response, jsonify, render_template, request, send_file
 
 from run_store import RunStore
 
@@ -97,6 +97,17 @@ def create_app(subdomain="", upgrade_bin="anix-upgrade", state_dir=DEFAULT_STATE
         if not store.start(cmd):
             return jsonify({"error": "Upgrade already in progress"}), 409
         return jsonify({"started": True}), 202
+
+    @bp.route("/log")
+    def download_log():
+        if not os.path.isfile(store.log_path):
+            return Response("No log available\n", mimetype="text/plain")
+        return send_file(
+            store.log_path,
+            mimetype="text/plain",
+            as_attachment=True,
+            download_name="anix-upgrade.log",
+        )
 
     @bp.route("/stream")
     def stream():

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
@@ -133,7 +133,8 @@
 
   <h5>Output</h5>
   <div id="log" class="log-box mb-2"></div>
-  <button class="btn btn-sm btn-outline-secondary" onclick="document.getElementById('log').innerHTML=''">Clear</button>
+  <button class="btn btn-sm btn-outline-secondary" onclick="_clearLog()">Clear</button>
+  <a id="dl-log-btn" class="btn btn-sm btn-outline-secondary ms-2" href="#">Download log</a>
 </div>
 
 <script>
@@ -156,12 +157,67 @@ function escHtml(s) {
   return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 }
 
-function appendLog(msg) {
+// ── Log output (batched to avoid browser freeze on large replays) ────────────
+
+const MAX_LOG_LINES = 500;
+let _logLineCount = 0;
+let _logQueue = [];
+let _logFlushTimer = null;
+let _logTruncNotice = null;
+
+function _clearLog() {
+  clearTimeout(_logFlushTimer);
+  _logFlushTimer = null;
+  _logQueue = [];
+  _logLineCount = 0;
+  _logTruncNotice = null;
+  $('log').innerHTML = '';
+}
+
+function _flushLog() {
+  _logFlushTimer = null;
+  if (!_logQueue.length) return;
   const log = $('log');
-  const line = document.createElement('span');
-  line.innerHTML = (ansiUp ? ansiUp.ansi_to_html(msg) : escHtml(msg)) + '\n';
-  log.appendChild(line);
-  log.scrollTop = log.scrollHeight;
+  const atBottom = log.scrollHeight - log.clientHeight - log.scrollTop < 20;
+  const frag = document.createDocumentFragment();
+  for (const html of _logQueue) {
+    const line = document.createElement('span');
+    line.innerHTML = html;
+    frag.appendChild(line);
+    _logLineCount++;
+  }
+  _logQueue = [];
+  log.appendChild(frag);
+  // Trim lines that exceed the cap (keep notice pinned at top)
+  if (_logLineCount > MAX_LOG_LINES) {
+    const toRemove = _logLineCount - MAX_LOG_LINES;
+    let removed = 0;
+    while (removed < toRemove) {
+      const first = log.firstChild;
+      if (!first) break;
+      if (first === _logTruncNotice) {
+        if (first.nextSibling) { log.removeChild(first.nextSibling); removed++; }
+        else break;
+      } else {
+        log.removeChild(first); removed++;
+      }
+    }
+    _logLineCount = MAX_LOG_LINES;
+    if (!_logTruncNotice) {
+      _logTruncNotice = document.createElement('div');
+      _logTruncNotice.style.cssText = 'color:#999;font-style:italic;padding:2px 0 8px';
+      _logTruncNotice.textContent = '[ Earlier output truncated — use "Download log" for full output ]';
+    }
+    if (log.firstChild !== _logTruncNotice) {
+      log.insertBefore(_logTruncNotice, log.firstChild);
+    }
+  }
+  if (atBottom) log.scrollTop = log.scrollHeight;
+}
+
+function appendLog(msg) {
+  _logQueue.push((ansiUp ? ansiUp.ansi_to_html(msg) : escHtml(msg)) + '\n');
+  if (!_logFlushTimer) _logFlushTimer = setTimeout(_flushLog, 50);
 }
 
 function resetRunButton() {
@@ -269,7 +325,7 @@ function attachStream() {
   es = new EventSource(subdomain + '/stream');
   // Also fires on auto-reconnect (e.g. the upgrade restarted this service):
   // clear the log so the server-side replay isn't duplicated.
-  es.onopen = () => { $('log').innerHTML = ''; };
+  es.onopen = () => { _clearLog(); };
   es.onmessage = (ev) => {
     if (ev.data === '[DONE]') {
       es.close();
@@ -318,6 +374,8 @@ if (_savedPath) {
   $('source-type').value = 'source';
   onSourceTypeChange();
 }
+
+$('dl-log-btn').href = subdomain + '/log';
 
 pollStatus();
 attachStream();

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_app.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_app.py
@@ -96,6 +96,21 @@ def test_stream_serves_finished_run(tmp_path):
     assert body.rstrip().endswith("data: [DONE]")
 
 
+def test_log_download_no_run(tmp_path):
+    resp = make_client(tmp_path).get("/log")
+    assert resp.status_code == 200
+    assert b"No log available" in resp.data
+
+
+def test_log_download_after_run(tmp_path):
+    client = make_client(tmp_path, script="echo hello-from-run")
+    client.post("/run", data={})
+    wait_status(client, "success")
+    resp = client.get("/log")
+    assert resp.status_code == 200
+    assert b"hello-from-run" in resp.data
+
+
 def test_list_dirs_works(tmp_path):
     client = make_client(tmp_path)
     (tmp_path / "subdir").mkdir()


### PR DESCRIPTION
Large nix build logs (512 KB replay) created thousands of individual DOM insertions that froze the browser. Batch SSE messages in 50 ms flush windows via DocumentFragment, cap the visible output at 500 lines with a truncation notice, and expose a /log download endpoint so the full log is always accessible.