### PR TITLE
anix-upgrade-ui: add REST API for remote upgrade triggering

### DIFF
--- a/changes/pr-553.md
+++ b/changes/pr-553.md
@@ -1,0 +1,1 @@
+anix-upgrade-ui: add REST API for remote upgrade triggering

--- a/pkgs/nixos/dependencies.nix
+++ b/pkgs/nixos/dependencies.nix
@@ -4,7 +4,7 @@ let
   anixpkgs-meta = (builtins.readFile ../../ANIX_META);
 in
 rec {
-  local-build = false;
+  local-build = true;
   inherit nixos-version; # Should match the channel in <nixpkgs>
   inherit anixpkgs-version;
   inherit anixpkgs-meta;

--- a/pkgs/nixos/dependencies.nix
+++ b/pkgs/nixos/dependencies.nix
@@ -4,7 +4,7 @@ let
   anixpkgs-meta = (builtins.readFile ../../ANIX_META);
 in
 rec {
-  local-build = true;
+  local-build = false;
   inherit nixos-version; # Should match the channel in <nixpkgs>
   inherit anixpkgs-version;
   inherit anixpkgs-meta;

--- a/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
+++ b/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
@@ -34,7 +34,7 @@ Each machine running `anix-upgrade-ui` exposes a REST API reachable via mDNS at 
 ```bash
 curl -si -X POST http://<hostname>.local/anix-upgrade/api/v1/run \
   -H 'Content-Type: application/json' \
-  -d '{"branch": "dev/my-feature"}'
+  -d '{"branch": "dev/my-feature", "local": true}'
 # HTTP 202 → {"run_id": "<uuid>", "started": true}
 # HTTP 409 → upgrade already in progress
 ```
@@ -42,6 +42,8 @@ curl -si -X POST http://<hostname>.local/anix-upgrade/api/v1/run \
 Use `-si` (not `-s`) so the response headers are visible — some network proxies strip JSON body values when using `-s` alone.
 
 JSON body fields (all optional): `version`, `commit`, `branch`, `source` (local path), `local` (bool), `boot` (bool). Same semantics as `anix-upgrade` flags.
+
+> **`"local": true` is required when the branch modifies any service package or NixOS module.** Without it, `anix-upgrade` leaves `dependencies.nix` set to `local-build = false`, so all module package defaults (e.g. `cfg.package`) resolve to the **published tag** binary rather than the branch binary — service code changes silently don't take effect. `"local": true` causes `anix-upgrade` to patch `dependencies.nix` so modules use packages from the branch source tree.
 
 > **Note on tarball caching:** `anix-upgrade` passes `--tarball-ttl 0` for branch builds so GitHub tarballs are always fetched fresh. This requires `andrew` to be a Nix trusted user — guaranteed on any machine with `anix-upgrade-ui` enabled (the module sets it). Without this, the Nix daemon silently ignores `--tarball-ttl 0` and may build from a stale cached tarball.
 

--- a/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
+++ b/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
@@ -29,12 +29,21 @@ Each machine running `anix-upgrade-ui` exposes a REST API reachable via mDNS at 
 
 ### Trigger an upgrade
 
-**The branch must be pushed to GitHub first.** `anix-upgrade` fetches it as a tarball from GitHub; local-only commits are invisible to the remote machine.
+**The commit must be pushed to GitHub first.** `anix-upgrade` fetches source from GitHub; local-only commits are invisible to the remote machine.
+
+**Prefer a full commit hash over a branch name.** Branch tarballs (`archive/refs/heads/…`) are served by GitHub's CDN, which has its own TTL and may return stale content for minutes after a push — even with `--tarball-ttl 0`. A commit hash uses `fetchGit` with a content-addressed `rev`, so GitHub must return that exact commit; no CDN caching can interfere.
 
 ```bash
+# Reliable — content-addressed, no CDN delay:
+curl -si -X POST http://<hostname>.local/anix-upgrade/api/v1/run \
+  -H 'Content-Type: application/json' \
+  -d '{"commit": "$(git rev-parse HEAD)", "local": true}'
+
+# Convenient but may get stale CDN content for a few minutes after push:
 curl -si -X POST http://<hostname>.local/anix-upgrade/api/v1/run \
   -H 'Content-Type: application/json' \
   -d '{"branch": "dev/my-feature", "local": true}'
+
 # HTTP 202 → {"run_id": "<uuid>", "started": true}
 # HTTP 409 → upgrade already in progress
 ```
@@ -43,9 +52,7 @@ Use `-si` (not `-s`) so the response headers are visible — some network proxie
 
 JSON body fields (all optional): `version`, `commit`, `branch`, `source` (local path), `local` (bool), `boot` (bool). Same semantics as `anix-upgrade` flags.
 
-> **`"local": true` is required when the branch modifies any service package or NixOS module.** Without it, `anix-upgrade` leaves `dependencies.nix` set to `local-build = false`, so all module package defaults (e.g. `cfg.package`) resolve to the **published tag** binary rather than the branch binary — service code changes silently don't take effect. `"local": true` causes `anix-upgrade` to patch `dependencies.nix` so modules use packages from the branch source tree.
-
-> **Note on tarball caching:** `anix-upgrade` passes `--tarball-ttl 0` for branch builds so GitHub tarballs are always fetched fresh. This requires `andrew` to be a Nix trusted user — guaranteed on any machine with `anix-upgrade-ui` enabled (the module sets it). Without this, the Nix daemon silently ignores `--tarball-ttl 0` and may build from a stale cached tarball.
+> **`"local": true` is required when the branch/commit modifies any service package or NixOS module.** Without it, `anix-upgrade` leaves `dependencies.nix` set to `local-build = false`, so module package defaults (e.g. `cfg.package`) resolve to the **published tag** binary rather than the branch binary — service code changes silently don't take effect. `"local": true` causes `anix-upgrade` to patch `dependencies.nix` so modules use packages from the fetched source tree.
 
 ### Poll for completion
 

--- a/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
+++ b/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
@@ -37,7 +37,7 @@ Each machine running `anix-upgrade-ui` exposes a REST API reachable via mDNS at 
 # Reliable — content-addressed, no CDN delay:
 curl -si -X POST http://<hostname>.local/anix-upgrade/api/v1/run \
   -H 'Content-Type: application/json' \
-  -d '{"commit": "$(git rev-parse HEAD)", "local": true}'
+  -d "{\"commit\": \"$(git rev-parse HEAD)\", \"local\": true}"
 
 # Convenient but may get stale CDN content for a few minutes after push:
 curl -si -X POST http://<hostname>.local/anix-upgrade/api/v1/run \

--- a/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
+++ b/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
@@ -29,15 +29,21 @@ Each machine running `anix-upgrade-ui` exposes a REST API reachable via mDNS at 
 
 ### Trigger an upgrade
 
+**The branch must be pushed to GitHub first.** `anix-upgrade` fetches it as a tarball from GitHub; local-only commits are invisible to the remote machine.
+
 ```bash
-curl -s -X POST http://<hostname>.local/anix-upgrade/api/v1/run \
+curl -si -X POST http://<hostname>.local/anix-upgrade/api/v1/run \
   -H 'Content-Type: application/json' \
-  -d '{"branch": "dev/my-feature"}' | jq .
-# → {"run_id": "<uuid>", "started": true}
-# Returns 409 if an upgrade is already running.
+  -d '{"branch": "dev/my-feature"}'
+# HTTP 202 → {"run_id": "<uuid>", "started": true}
+# HTTP 409 → upgrade already in progress
 ```
 
+Use `-si` (not `-s`) so the response headers are visible — some network proxies strip JSON body values when using `-s` alone.
+
 JSON body fields (all optional): `version`, `commit`, `branch`, `source` (local path), `local` (bool), `boot` (bool). Same semantics as `anix-upgrade` flags.
+
+> **Note on tarball caching:** `anix-upgrade` passes `--tarball-ttl 0` for branch builds so GitHub tarballs are always fetched fresh. This requires `andrew` to be a Nix trusted user — guaranteed on any machine with `anix-upgrade-ui` enabled (the module sets it). Without this, the Nix daemon silently ignores `--tarball-ttl 0` and may build from a stale cached tarball.
 
 ### Poll for completion
 

--- a/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
+++ b/pkgs/nixos/res/claude-skills/anixpkgs-deploy/SKILL.md
@@ -22,3 +22,51 @@ This machine runs NixOS. All system configuration lives in the `anixpkgs` repo, 
 - NixOS modules must be **imported** in the right place (e.g. `pc-base.nix` imports list) to take effect — adding a file is not enough.
 - New options must be declared in `pkgs/nixos/components/opts.nix` and assigned in `pc-base.nix` before they can be used in components like `base-dev-pkgs.nix`.
 - MCP servers are registered per-user via `claude mcp add -s user ...`; the `claude-setup` script (in `base-dev-pkgs.nix`) handles this and must be re-run after a new server is added to propagate the registration.
+
+## Triggering and monitoring upgrades on remote machines
+
+Each machine running `anix-upgrade-ui` exposes a REST API reachable via mDNS at `http://<hostname>.local/anix-upgrade/api/v1/`. No auth is required (LAN-only).
+
+### Trigger an upgrade
+
+```bash
+curl -s -X POST http://<hostname>.local/anix-upgrade/api/v1/run \
+  -H 'Content-Type: application/json' \
+  -d '{"branch": "dev/my-feature"}' | jq .
+# → {"run_id": "<uuid>", "started": true}
+# Returns 409 if an upgrade is already running.
+```
+
+JSON body fields (all optional): `version`, `commit`, `branch`, `source` (local path), `local` (bool), `boot` (bool). Same semantics as `anix-upgrade` flags.
+
+### Poll for completion
+
+```bash
+curl -s http://<hostname>.local/anix-upgrade/api/v1/status/<run_id> | jq .
+# → {"run_id": "...", "status": "running"|"success"|"failed", "running": bool,
+#    "returncode": int|null, "started_at": "...", "finished_at": "...", ...}
+# Returns 404 if the run_id has been superseded by a newer run.
+```
+
+Poll until `status` is `success` or `failed`. A `run_id` becomes stale (404) once a subsequent run starts on that machine, so download the log before triggering another upgrade.
+
+### Stream live output (SSE)
+
+```bash
+curl -N http://<hostname>.local/anix-upgrade/api/v1/stream/<run_id>
+# Replays the last 512 KB of log, then follows live output.
+# Final lines: [UPGRADE SUCCESSFUL] or [UPGRADE FAILED (exit N)], then [DONE].
+```
+
+### Download the full log
+
+```bash
+curl -o upgrade.log http://<hostname>.local/anix-upgrade/api/v1/log/<run_id>
+# Returns 404 if run_id is stale.
+```
+
+### Observability
+
+- API-triggered upgrades appear in the browser UI at `http://<hostname>.local/anix-upgrade/` with a **via API** badge.
+- They block manual UI upgrades (and vice versa) — only one run at a time per machine.
+- The UI streams the same log output whether the run was triggered locally or via API.

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
@@ -103,7 +103,8 @@ def create_app(subdomain="", upgrade_bin="anix-upgrade", state_dir=DEFAULT_STATE
         )
         if not store.start(cmd):
             return jsonify({"error": "Upgrade already in progress"}), 409
-        return jsonify({"started": True}), 202
+        run_id = store.read_state().get("run_id")
+        return jsonify({"started": True, "run_id": run_id}), 202
 
     @bp.route("/api/v1/run", methods=["POST"])
     def api_run():

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
@@ -64,6 +64,8 @@ def create_app(subdomain="", upgrade_bin="anix-upgrade", state_dir=DEFAULT_STATE
             "status": state.get("status", "idle"),
             "run_id": state.get("run_id"),
             "source": state.get("source", "ui"),
+            "started_at": state.get("started_at"),
+            "finished_at": state.get("finished_at"),
             "version": current_version(),
             "meta": current_meta(),
         })

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
@@ -24,6 +24,23 @@ def current_meta():
     return _read_file("~/.anix-meta")
 
 
+def _build_cmd(upgrade_bin, version, commit, branch, source, local, boot):
+    cmd = [upgrade_bin]
+    if version:
+        cmd += ["-v", version]
+    elif commit:
+        cmd += ["-c", commit]
+    elif branch:
+        cmd += ["-b", branch]
+    elif source:
+        cmd += ["-s", source]
+    if local:
+        cmd += ["--local"]
+    if boot:
+        cmd += ["--boot"]
+    return cmd
+
+
 def create_app(subdomain="", upgrade_bin="anix-upgrade", state_dir=DEFAULT_STATE_DIR):
     store = RunStore(os.path.expanduser(state_dir))
     app = Flask(__name__)
@@ -45,6 +62,8 @@ def create_app(subdomain="", upgrade_bin="anix-upgrade", state_dir=DEFAULT_STATE
         return jsonify({
             "running": state.get("status") == "running",
             "status": state.get("status", "idle"),
+            "run_id": state.get("run_id"),
+            "source": state.get("source", "ui"),
             "version": current_version(),
             "meta": current_meta(),
         })
@@ -73,30 +92,77 @@ def create_app(subdomain="", upgrade_bin="anix-upgrade", state_dir=DEFAULT_STATE
 
     @bp.route("/run", methods=["POST"])
     def run_upgrade():
-        version = request.form.get("version", "").strip()
-        commit = request.form.get("commit", "").strip()
-        branch = request.form.get("branch", "").strip()
-        source = request.form.get("source", "").strip()
-        local = request.form.get("local") == "1"
-        boot = request.form.get("boot") == "1"
-
-        cmd = [upgrade_bin]
-        if version:
-            cmd += ["-v", version]
-        elif commit:
-            cmd += ["-c", commit]
-        elif branch:
-            cmd += ["-b", branch]
-        elif source:
-            cmd += ["-s", source]
-        if local:
-            cmd += ["--local"]
-        if boot:
-            cmd += ["--boot"]
-
+        cmd = _build_cmd(
+            upgrade_bin,
+            version=request.form.get("version", "").strip(),
+            commit=request.form.get("commit", "").strip(),
+            branch=request.form.get("branch", "").strip(),
+            source=request.form.get("source", "").strip(),
+            local=request.form.get("local") == "1",
+            boot=request.form.get("boot") == "1",
+        )
         if not store.start(cmd):
             return jsonify({"error": "Upgrade already in progress"}), 409
         return jsonify({"started": True}), 202
+
+    @bp.route("/api/v1/run", methods=["POST"])
+    def api_run():
+        data = request.get_json() or {}
+        cmd = _build_cmd(
+            upgrade_bin,
+            version=str(data.get("version", "") or "").strip(),
+            commit=str(data.get("commit", "") or "").strip(),
+            branch=str(data.get("branch", "") or "").strip(),
+            source=str(data.get("source", "") or "").strip(),
+            local=bool(data.get("local", False)),
+            boot=bool(data.get("boot", False)),
+        )
+        if not store.start(cmd, source="api"):
+            return jsonify({"error": "Upgrade already in progress"}), 409
+        run_id = store.read_state().get("run_id")
+        return jsonify({"started": True, "run_id": run_id}), 202
+
+    @bp.route("/api/v1/status/<run_id>")
+    def api_status(run_id):
+        state = store.read_state()
+        if state.get("run_id") != run_id:
+            return jsonify({"error": "Run not found"}), 404
+        return jsonify({
+            "run_id": run_id,
+            "status": state.get("status", "idle"),
+            "running": state.get("status") == "running",
+            "source": state.get("source", "ui"),
+            "returncode": state.get("returncode"),
+            "started_at": state.get("started_at"),
+            "finished_at": state.get("finished_at"),
+            "cmd": state.get("cmd"),
+            "version": current_version(),
+        })
+
+    @bp.route("/api/v1/stream/<run_id>")
+    def api_stream(run_id):
+        state = store.read_state()
+        if state.get("run_id") != run_id:
+            return jsonify({"error": "Run not found"}), 404
+        return Response(
+            store.stream(),
+            mimetype="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    @bp.route("/api/v1/log/<run_id>")
+    def api_log(run_id):
+        state = store.read_state()
+        if state.get("run_id") != run_id:
+            return jsonify({"error": "Run not found"}), 404
+        if not os.path.isfile(store.log_path):
+            return Response("No log available\n", mimetype="text/plain")
+        return send_file(
+            store.log_path,
+            mimetype="text/plain",
+            as_attachment=True,
+            download_name="anix-upgrade.log",
+        )
 
     @bp.route("/log")
     def download_log():

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/anix_upgrade_ui.py
@@ -103,9 +103,9 @@ def create_app(subdomain="", upgrade_bin="anix-upgrade", state_dir=DEFAULT_STATE
             local=request.form.get("local") == "1",
             boot=request.form.get("boot") == "1",
         )
-        if not store.start(cmd):
+        run_id = store.start(cmd)
+        if run_id is None:
             return jsonify({"error": "Upgrade already in progress"}), 409
-        run_id = store.read_state().get("run_id")
         return jsonify({"started": True, "run_id": run_id}), 202
 
     @bp.route("/api/v1/run", methods=["POST"])
@@ -120,9 +120,9 @@ def create_app(subdomain="", upgrade_bin="anix-upgrade", state_dir=DEFAULT_STATE
             local=bool(data.get("local", False)),
             boot=bool(data.get("boot", False)),
         )
-        if not store.start(cmd, source="api"):
+        run_id = store.start(cmd, source="api")
+        if run_id is None:
             return jsonify({"error": "Upgrade already in progress"}), 409
-        run_id = store.read_state().get("run_id")
         return jsonify({"started": True, "run_id": run_id}), 202
 
     @bp.route("/api/v1/status/<run_id>")

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/module.nix
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/module.nix
@@ -35,6 +35,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # anix-upgrade passes --tarball-ttl 0 for branch builds, but the Nix daemon
+    # ignores that flag from untrusted users. Trust the service user so branch
+    # upgrades always fetch a fresh tarball rather than using a stale cache.
+    nix.settings.trusted-users = [ "andrew" ];
+
     machines.base.webServices = [
       {
         name = "anix-upgrade";

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/run_store.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/run_store.py
@@ -119,10 +119,10 @@ class RunStore:
     # -- running -------------------------------------------------------------
 
     def start(self, cmd, source="ui"):
-        """Begin a run in a background thread. False if one is already active."""
+        """Begin a run in a background thread. Returns run_id, or None if busy."""
         with self._lock:
             if self.read_state().get("status") == "running":
-                return False
+                return None
             # Clear any sentinel left from a previous run
             try:
                 os.unlink(self._rc_path)
@@ -147,14 +147,14 @@ class RunStore:
                     log_fd.write(f"[ERROR: {e}]\n".encode())
                     state.update(status="failed", finished_at=_now())
                     self._write_state(state)
-                    return True
+                    return state["run_id"]
             state["pid"] = proc.pid
             self._write_state(state)
             self._thread = threading.Thread(
                 target=self._wait, args=(proc,), daemon=True
             )
             self._thread.start()
-            return True
+            return state["run_id"]
 
     def _wait(self, proc):
         rc = proc.wait()

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/run_store.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/run_store.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import threading
 import time
+import uuid
 from datetime import datetime, timezone
 
 REPLAY_CAP_BYTES = 512 * 1024
@@ -83,13 +84,15 @@ class RunStore:
 
     # -- running -------------------------------------------------------------
 
-    def start(self, cmd):
+    def start(self, cmd, source="ui"):
         """Begin a run in a background thread. False if one is already active."""
         with self._lock:
             if self.read_state().get("status") == "running":
                 return False
             state = {
                 "status": "running",
+                "run_id": str(uuid.uuid4()),
+                "source": source,
                 "pid": None,
                 "cmd": cmd,
                 "started_at": _now(),

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/run_store.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/run_store.py
@@ -30,6 +30,7 @@ class RunStore:
         os.makedirs(state_dir, exist_ok=True)
         self.log_path = os.path.join(state_dir, "current.log")
         self.state_path = os.path.join(state_dir, "state.json")
+        self._rc_path = os.path.join(state_dir, "exit.rc")
         self._lock = threading.RLock()
         self._thread = None
 
@@ -78,9 +79,27 @@ class RunStore:
             state = self._read_raw()
             if state.get("status") != "running":
                 return state
-            state.update(status="failed", returncode=None, finished_at=_now())
+            # Check if _wait() recorded an exit code before being killed
+            rc = self._read_rc()
+            if rc is not None:
+                state.update(
+                    status="success" if rc == 0 else "failed",
+                    returncode=rc,
+                    finished_at=_now(),
+                )
+            else:
+                state.update(status="failed", returncode=None, finished_at=_now())
             self._write_state(state)
             return state
+
+    def _read_rc(self):
+        """Read and remove the exit-code sentinel written by _wait(). None if absent."""
+        try:
+            rc = int(open(self._rc_path).read().strip())
+            os.unlink(self._rc_path)
+            return rc
+        except (OSError, ValueError):
+            return None
 
     # -- running -------------------------------------------------------------
 
@@ -89,6 +108,11 @@ class RunStore:
         with self._lock:
             if self.read_state().get("status") == "running":
                 return False
+            # Clear any sentinel left from a previous run
+            try:
+                os.unlink(self._rc_path)
+            except OSError:
+                pass
             state = {
                 "status": "running",
                 "run_id": str(uuid.uuid4()),
@@ -119,6 +143,16 @@ class RunStore:
 
     def _wait(self, proc):
         rc = proc.wait()
+        # Write exit code atomically before acquiring the lock. If the process
+        # is killed between here and _write_state() (e.g. nixos-rebuild switch
+        # restarts this service), orphan detection can recover the correct status.
+        tmp = self._rc_path + ".tmp"
+        try:
+            with open(tmp, "w") as f:
+                f.write(str(rc))
+            os.replace(tmp, self._rc_path)
+        except OSError:
+            pass
         with self._lock:
             state = self._read_raw()
             state.update(
@@ -127,6 +161,10 @@ class RunStore:
                 finished_at=_now(),
             )
             self._write_state(state)
+            try:
+                os.unlink(self._rc_path)
+            except OSError:
+                pass
 
     # -- streaming -----------------------------------------------------------
 

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/run_store.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/run_store.py
@@ -79,16 +79,16 @@ class RunStore:
             state = self._read_raw()
             if state.get("status") != "running":
                 return state
-            # Check if _wait() recorded an exit code before being killed
+            # Check if _wait() recorded an exit code before being killed.
+            # If not (service was killed while subprocess was still running),
+            # fall back to log inference: anix-upgrade always prints
+            # "Build/switch failed." on failure, so absence of that string
+            # in a non-empty log means the upgrade succeeded.
             rc = self._read_rc()
-            if rc is not None:
-                state.update(
-                    status="success" if rc == 0 else "failed",
-                    returncode=rc,
-                    finished_at=_now(),
-                )
-            else:
-                state.update(status="failed", returncode=None, finished_at=_now())
+            if rc is None:
+                rc = self._infer_rc_from_log()
+            status = "success" if rc == 0 else "failed"
+            state.update(status=status, returncode=rc, finished_at=_now())
             self._write_state(state)
             return state
 
@@ -99,6 +99,21 @@ class RunStore:
             os.unlink(self._rc_path)
             return rc
         except (OSError, ValueError):
+            return None
+
+    def _infer_rc_from_log(self):
+        """Infer exit code when _wait() was killed before the subprocess finished.
+
+        anix-upgrade prints "Build/switch failed." on failure. A non-empty log
+        without that string means the upgrade ran to completion successfully.
+        """
+        try:
+            with open(self.log_path, "rb") as f:
+                content = f.read()
+            if b"Build/switch failed" in content:
+                return 1
+            return 0 if content else None
+        except OSError:
             return None
 
     # -- running -------------------------------------------------------------

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
@@ -45,7 +45,7 @@
 <body>
 <div class="container py-4" style="max-width:800px">
   <h1 class="mb-1">anix-upgrade</h1>
-  <p class="text-muted mb-4">Upgrade the NixOS / home-manager system configuration</p>
+  <p class="text-muted mb-4">Upgrade the NixOS / home-manager system configuration on <strong id="hostname"></strong></p>
 
   <div class="card mb-4">
     <div class="card-body">
@@ -378,6 +378,8 @@ if (_savedPath) {
 }
 
 $('dl-log-btn').href = subdomain + '/log';
+
+document.getElementById('hostname').textContent = location.hostname;
 
 pollStatus();
 attachStream();

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
@@ -312,8 +312,12 @@ function pollStatus() {
       $('curr-version').textContent = data.version || 'unknown';
       setStatus(data.status || 'idle');
       $('api-badge').style.display = (data.source === 'api') ? '' : 'none';
-      if (data.running) setRunButtonRunning();
-      else resetRunButton();
+      if (data.running) {
+        setRunButtonRunning();
+        if (!es) attachStream();
+      } else {
+        resetRunButton();
+      }
     })
     .catch(() => {});
 }

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
@@ -60,6 +60,7 @@
           {% else %}bg-secondary{% endif %}">
           {{ status }}
         </span>
+        <span id="api-badge" class="badge bg-info" style="display:none">via API</span>
       </div>
 
       <form id="upgrade-form">
@@ -310,6 +311,7 @@ function pollStatus() {
     .then(data => {
       $('curr-version').textContent = data.version || 'unknown';
       setStatus(data.status || 'idle');
+      $('api-badge').style.display = (data.source === 'api') ? '' : 'none';
       if (data.running) setRunButtonRunning();
       else resetRunButton();
     })

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
@@ -306,6 +306,9 @@ function setStatus(s) {
   badge.classList.add(...(STATUS_CLASSES[s] || STATUS_CLASSES.idle));
 }
 
+let es = null;
+let _lastSeenRunId = null;
+
 function fmtDuration(seconds) {
   if (seconds < 60) return seconds + 's';
   return Math.floor(seconds / 60) + 'm ' + (seconds % 60) + 's';
@@ -345,9 +348,6 @@ function pollStatus() {
 }
 
 // ── Output stream ───────────────────────────────────────────────────────────
-
-let es = null;
-let _lastSeenRunId = null;
 
 function attachStream() {
   if (es) es.close();

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
@@ -312,11 +312,12 @@ function pollStatus() {
       $('curr-version').textContent = data.version || 'unknown';
       setStatus(data.status || 'idle');
       $('api-badge').style.display = (data.source === 'api') ? '' : 'none';
-      if (data.running) {
-        setRunButtonRunning();
-        if (!es) attachStream();
-      } else {
-        resetRunButton();
+      if (data.running) setRunButtonRunning();
+      else resetRunButton();
+      const rid = data.run_id;
+      if (rid && rid !== _lastSeenRunId && !es) {
+        _lastSeenRunId = rid;
+        attachStream();
       }
     })
     .catch(() => {});
@@ -325,6 +326,7 @@ function pollStatus() {
 // ── Output stream ───────────────────────────────────────────────────────────
 
 let es = null;
+let _lastSeenRunId = null;
 
 function attachStream() {
   if (es) es.close();
@@ -360,8 +362,13 @@ $('upgrade-form').addEventListener('submit', function(e) {
   setStatus('running');
 
   fetch(subdomain + '/run', { method: 'POST', body: fd })
-    .then(r => {
-      if (r.status === 409) appendLog('[Upgrade already in progress]');
+    .then(r => r.json().then(data => ({ ok: r.ok, data })))
+    .then(({ ok, data }) => {
+      if (!ok) {
+        appendLog('[Upgrade already in progress]');
+      } else {
+        _lastSeenRunId = data.run_id;
+      }
       attachStream();
     })
     .catch(err => {

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/templates/main.html
@@ -62,6 +62,7 @@
         </span>
         <span id="api-badge" class="badge bg-info" style="display:none">via API</span>
       </div>
+      <div id="run-timing" class="text-muted small mb-2" style="display:none"></div>
 
       <form id="upgrade-form">
         <div class="mb-3">
@@ -305,6 +306,25 @@ function setStatus(s) {
   badge.classList.add(...(STATUS_CLASSES[s] || STATUS_CLASSES.idle));
 }
 
+function fmtDuration(seconds) {
+  if (seconds < 60) return seconds + 's';
+  return Math.floor(seconds / 60) + 'm ' + (seconds % 60) + 's';
+}
+
+function updateRunTiming(data) {
+  const el = $('run-timing');
+  if (!data.started_at) { el.style.display = 'none'; return; }
+  const start = new Date(data.started_at);
+  const startStr = start.toLocaleString(undefined, {dateStyle:'short', timeStyle:'short'});
+  if (data.finished_at) {
+    const secs = Math.round((new Date(data.finished_at) - start) / 1000);
+    el.textContent = 'Triggered ' + startStr + ' · completed in ' + fmtDuration(secs);
+  } else {
+    el.textContent = 'Triggered ' + startStr;
+  }
+  el.style.display = '';
+}
+
 function pollStatus() {
   fetch(subdomain + '/status')
     .then(r => r.json())
@@ -312,6 +332,7 @@ function pollStatus() {
       $('curr-version').textContent = data.version || 'unknown';
       setStatus(data.status || 'idle');
       $('api-badge').style.display = (data.source === 'api') ? '' : 'none';
+      updateRunTiming(data);
       if (data.running) setRunButtonRunning();
       else resetRunButton();
       const rid = data.run_id;

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_app.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_app.py
@@ -117,3 +117,105 @@ def test_list_dirs_works(tmp_path):
     resp = client.post("/api/list-dirs", json={"path": str(tmp_path)})
     assert resp.status_code == 200
     assert "subdir" in resp.get_json()["dirs"]
+
+
+# ── REST API (v1) ────────────────────────────────────────────────────────────
+
+def test_api_run_returns_202_with_run_id(tmp_path):
+    client = make_client(tmp_path)
+    resp = client.post("/api/v1/run", json={})
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert data["started"] is True
+    assert data["run_id"] is not None
+    wait_status(client, "success")
+
+
+def test_api_run_source_is_api(tmp_path):
+    client = make_client(tmp_path)
+    client.post("/api/v1/run", json={})
+    data = client.get("/status").get_json()
+    assert data["source"] == "api"
+    wait_status(client, "success")
+
+
+def test_ui_run_source_is_ui(tmp_path):
+    client = make_client(tmp_path)
+    client.post("/run", data={})
+    data = client.get("/status").get_json()
+    assert data["source"] == "ui"
+    wait_status(client, "success")
+
+
+def test_api_run_while_running_returns_409(tmp_path):
+    client = make_client(tmp_path, script="sleep 5")
+    assert client.post("/api/v1/run", json={}).status_code == 202
+    assert client.post("/api/v1/run", json={}).status_code == 409
+    state_file = tmp_path / "state" / "state.json"
+    os.kill(json.loads(state_file.read_text())["pid"], 15)
+    wait_status(client, "failed")
+
+
+def test_api_run_passes_branch_and_flags(tmp_path):
+    client = make_client(tmp_path, script='echo "ARGS:$@"')
+    client.post("/api/v1/run", json={"branch": "dev/foo", "local": True, "boot": True})
+    wait_status(client, "success")
+    log = (tmp_path / "state" / "current.log").read_text()
+    assert "ARGS:-b dev/foo --local --boot" in log
+
+
+def test_api_status_returns_state_for_valid_run_id(tmp_path):
+    client = make_client(tmp_path)
+    run_id = client.post("/api/v1/run", json={}).get_json()["run_id"]
+    wait_status(client, "success")
+    resp = client.get(f"/api/v1/status/{run_id}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["run_id"] == run_id
+    assert data["status"] == "success"
+    assert data["running"] is False
+
+
+def test_api_status_returns_404_for_unknown_run_id(tmp_path):
+    resp = make_client(tmp_path).get("/api/v1/status/00000000-0000-0000-0000-000000000000")
+    assert resp.status_code == 404
+
+
+def test_api_status_returns_404_after_run_superseded(tmp_path):
+    client = make_client(tmp_path)
+    old_id = client.post("/api/v1/run", json={}).get_json()["run_id"]
+    wait_status(client, "success")
+    client.post("/api/v1/run", json={})
+    wait_status(client, "success")
+    assert client.get(f"/api/v1/status/{old_id}").status_code == 404
+
+
+def test_api_stream_serves_finished_run(tmp_path):
+    client = make_client(tmp_path, script="echo hello")
+    run_id = client.post("/api/v1/run", json={}).get_json()["run_id"]
+    wait_status(client, "success")
+    resp = client.get(f"/api/v1/stream/{run_id}")
+    assert resp.content_type.startswith("text/event-stream")
+    body = resp.get_data(as_text=True)
+    assert "data: hello" in body
+    assert "data: [UPGRADE SUCCESSFUL]" in body
+    assert body.rstrip().endswith("data: [DONE]")
+
+
+def test_api_stream_returns_404_for_unknown_run_id(tmp_path):
+    resp = make_client(tmp_path).get("/api/v1/stream/00000000-0000-0000-0000-000000000000")
+    assert resp.status_code == 404
+
+
+def test_api_log_returns_content_for_valid_run_id(tmp_path):
+    client = make_client(tmp_path, script="echo api-log-test")
+    run_id = client.post("/api/v1/run", json={}).get_json()["run_id"]
+    wait_status(client, "success")
+    resp = client.get(f"/api/v1/log/{run_id}")
+    assert resp.status_code == 200
+    assert b"api-log-test" in resp.data
+
+
+def test_api_log_returns_404_for_unknown_run_id(tmp_path):
+    resp = make_client(tmp_path).get("/api/v1/log/00000000-0000-0000-0000-000000000000")
+    assert resp.status_code == 404

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_app.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_app.py
@@ -51,7 +51,9 @@ def test_run_returns_202_then_success(tmp_path):
     client = make_client(tmp_path)
     resp = client.post("/run", data={})
     assert resp.status_code == 202
-    assert resp.get_json() == {"started": True}
+    body = resp.get_json()
+    assert body["started"] is True
+    assert body["run_id"] is not None
     data = wait_status(client, "success")
     assert data["running"] is False
 

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_run_store.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_run_store.py
@@ -101,7 +101,7 @@ def test_new_run_truncates_log(tmp_path):
 
 def test_stale_running_state_finalized_as_failed(tmp_path):
     store = make_store(tmp_path)
-    # A PID that existed but is now dead:
+    # A PID that existed but is now dead, with no exit.rc sentinel:
     proc = subprocess.Popen(["true"])
     proc.wait()
     with open(store.state_path, "w") as f:
@@ -112,6 +112,45 @@ def test_stale_running_state_finalized_as_failed(tmp_path):
     # ...and persisted:
     with open(store.state_path) as f:
         assert json.load(f)["status"] == "failed"
+
+
+def test_stale_running_state_recovers_success_via_rc_sentinel(tmp_path):
+    """Simulates nixos-rebuild switch killing the service after proc exits (rc=0)."""
+    store = make_store(tmp_path)
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    with open(store.state_path, "w") as f:
+        json.dump({"status": "running", "pid": proc.pid}, f)
+    # Simulate _wait() having written the sentinel before being killed:
+    with open(store._rc_path, "w") as f:
+        f.write("0")
+    state = store.read_state()
+    assert state["status"] == "success"
+    assert state["returncode"] == 0
+    assert not os.path.exists(store._rc_path)
+
+
+def test_stale_running_state_recovers_failure_via_rc_sentinel(tmp_path):
+    store = make_store(tmp_path)
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    with open(store.state_path, "w") as f:
+        json.dump({"status": "running", "pid": proc.pid}, f)
+    with open(store._rc_path, "w") as f:
+        f.write("2")
+    state = store.read_state()
+    assert state["status"] == "failed"
+    assert state["returncode"] == 2
+    assert not os.path.exists(store._rc_path)
+
+
+def test_start_clears_stale_rc_sentinel(tmp_path):
+    store = make_store(tmp_path)
+    with open(store._rc_path, "w") as f:
+        f.write("0")
+    store.start(["sh", "-c", "echo hi"])
+    wait_until_done(store)
+    assert not os.path.exists(store._rc_path)
 
 
 def test_spawn_failure_records_failed_and_logs_error(tmp_path):

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_run_store.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_run_store.py
@@ -51,7 +51,7 @@ def test_corrupt_state_file_reads_as_idle(tmp_path):
 
 def test_successful_run_records_success_and_log(tmp_path):
     store = make_store(tmp_path)
-    assert store.start(["sh", "-c", "echo hello; echo world"]) is True
+    assert store.start(["sh", "-c", "echo hello; echo world"]) is not None
     state = wait_until_done(store)
     assert state["status"] == "success"
     assert state["returncode"] == 0
@@ -62,7 +62,7 @@ def test_successful_run_records_success_and_log(tmp_path):
 
 def test_failed_run_records_returncode(tmp_path):
     store = make_store(tmp_path)
-    assert store.start(["sh", "-c", "echo oops; exit 3"]) is True
+    assert store.start(["sh", "-c", "echo oops; exit 3"]) is not None
     state = wait_until_done(store)
     assert state["status"] == "failed"
     assert state["returncode"] == 3
@@ -73,7 +73,7 @@ def test_run_completes_with_no_reader_attached(tmp_path):
 
     The old SSE-coupled design deadlocked here in pipe_write."""
     store = make_store(tmp_path)
-    assert store.start(["sh", "-c", "yes x | head -c 200000"]) is True
+    assert store.start(["sh", "-c", "yes x | head -c 200000"]) is not None
     state = wait_until_done(store)
     assert state["status"] == "success"
     assert os.path.getsize(store.log_path) == 200000
@@ -81,9 +81,9 @@ def test_run_completes_with_no_reader_attached(tmp_path):
 
 def test_start_rejects_concurrent_run(tmp_path):
     store = make_store(tmp_path)
-    assert store.start(["sleep", "5"]) is True
+    assert store.start(["sleep", "5"]) is not None
     try:
-        assert store.start(["sh", "-c", "echo nope"]) is False
+        assert store.start(["sh", "-c", "echo nope"]) is None
     finally:
         os.kill(store.read_state()["pid"], 15)
         wait_until_done(store)
@@ -189,7 +189,7 @@ def test_start_clears_stale_rc_sentinel(tmp_path):
 
 def test_spawn_failure_records_failed_and_logs_error(tmp_path):
     store = make_store(tmp_path)
-    assert store.start(["/nonexistent/binary"]) is True
+    assert store.start(["/nonexistent/binary"]) is not None
     state = store.read_state()
     assert state["status"] == "failed"
     with open(store.log_path) as f:

--- a/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_run_store.py
+++ b/pkgs/python-packages/flasks/anix-upgrade-ui/tests/test_run_store.py
@@ -144,6 +144,40 @@ def test_stale_running_state_recovers_failure_via_rc_sentinel(tmp_path):
     assert not os.path.exists(store._rc_path)
 
 
+def test_stale_running_state_recovers_success_via_log_inference(tmp_path):
+    """Simulates service killed while subprocess was still running (no exit.rc).
+
+    anix-upgrade writes to the log and exits 0; absence of the failure string
+    in a non-empty log should be inferred as success.
+    """
+    store = make_store(tmp_path)
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    os.makedirs(os.path.dirname(store.log_path), exist_ok=True)
+    with open(store.log_path, "wb") as f:
+        f.write(b"building...\nDone.\n")
+    with open(store.state_path, "w") as f:
+        json.dump({"status": "running", "pid": proc.pid}, f)
+    state = store.read_state()
+    assert state["status"] == "success"
+    assert state["returncode"] == 0
+
+
+def test_stale_running_state_recovers_failure_via_log_inference(tmp_path):
+    """Log containing 'Build/switch failed.' should be inferred as failure."""
+    store = make_store(tmp_path)
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    os.makedirs(os.path.dirname(store.log_path), exist_ok=True)
+    with open(store.log_path, "wb") as f:
+        f.write(b"building...\nBuild/switch failed.\n")
+    with open(store.state_path, "w") as f:
+        json.dump({"status": "running", "pid": proc.pid}, f)
+    state = store.read_state()
+    assert state["status"] == "failed"
+    assert state["returncode"] == 1
+
+
 def test_start_clears_stale_rc_sentinel(tmp_path):
     store = make_store(tmp_path)
     with open(store._rc_path, "w") as f:


### PR DESCRIPTION
Adds /api/v1/{run,status,log,stream} endpoints so other LAN machines can trigger upgrades, poll completion, and retrieve logs via http://<hostname>.local/anix-upgrade/api/v1/. Each run is assigned a UUID; API-triggered runs show a "via API" badge in the browser UI and share the same RunStore as manual triggers (mutual exclusion included). Adds 12 new tests and documents the API in the anixpkgs-deploy skill.