### PR TITLE
feat: bump sunnyside to 0.2.0 with bu/rs subcommands

### DIFF
--- a/changes/pr-559.md
+++ b/changes/pr-559.md
@@ -1,0 +1,1 @@
+feat: bump sunnyside to 0.2.0 with bu/rs subcommands

--- a/flake.lock
+++ b/flake.lock
@@ -938,15 +938,16 @@
     "sunnyside": {
       "flake": false,
       "locked": {
-        "lastModified": 1717568445,
-        "narHash": "sha256-U2wiyKsJ6ACiajkfULpkdCUJ2/xZKQqNgzIHQL9utIE=",
+        "lastModified": 1782453344,
+        "narHash": "sha256-6GB3UkF4sNcXOUBxlydWwWD/qKA4WKpc7HFx2wNZDsw=",
         "owner": "goromal",
         "repo": "sunnyside",
-        "rev": "d6605667490ce008321b32dea5732d7962609bf7",
+        "rev": "ee502edd1ed3a3260b8dc4d69cef48f4d161e405",
         "type": "github"
       },
       "original": {
         "owner": "goromal",
+        "ref": "dev/ssbu",
         "repo": "sunnyside",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -938,16 +938,15 @@
     "sunnyside": {
       "flake": false,
       "locked": {
-        "lastModified": 1782501062,
+        "lastModified": 1782521357,
         "narHash": "sha256-YBn5iN5xzxKxg4kjh2dbxkpG1v6i4AkHsG0ZO1kv+7Q=",
         "owner": "goromal",
         "repo": "sunnyside",
-        "rev": "89dd172afcad11eac2ad270722db1a2bf118d7f2",
+        "rev": "0da2719982d168969a9a793b85de9f6d8dd2e6f3",
         "type": "github"
       },
       "original": {
         "owner": "goromal",
-        "ref": "dev/ssbu",
         "repo": "sunnyside",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -938,11 +938,11 @@
     "sunnyside": {
       "flake": false,
       "locked": {
-        "lastModified": 1782453344,
-        "narHash": "sha256-6GB3UkF4sNcXOUBxlydWwWD/qKA4WKpc7HFx2wNZDsw=",
+        "lastModified": 1782501062,
+        "narHash": "sha256-YBn5iN5xzxKxg4kjh2dbxkpG1v6i4AkHsG0ZO1kv+7Q=",
         "owner": "goromal",
         "repo": "sunnyside",
-        "rev": "ee502edd1ed3a3260b8dc4d69cef48f4d161e405",
+        "rev": "89dd172afcad11eac2ad270722db1a2bf118d7f2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
     spelling-corrector.url = "github:goromal/spelling-corrector";
     spelling-corrector.flake = false;
 
-    sunnyside.url = "github:goromal/sunnyside";
+    sunnyside.url = "github:goromal/sunnyside/dev/ssbu";
     sunnyside.flake = false;
 
     symforce.url = "github:symforce-org/symforce?ref=refs/tags/v0.9.0";

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
     spelling-corrector.url = "github:goromal/spelling-corrector";
     spelling-corrector.flake = false;
 
-    sunnyside.url = "github:goromal/sunnyside/dev/ssbu";
+    sunnyside.url = "github:goromal/sunnyside";
     sunnyside.flake = false;
 
     symforce.url = "github:symforce-org/symforce?ref=refs/tags/v0.9.0";

--- a/pkgs/rust-packages/sunnyside/default.nix
+++ b/pkgs/rust-packages/sunnyside/default.nix
@@ -5,9 +5,9 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "sunnyside";
-  version = "0.1.1";
+  version = "0.2.0";
   src = pkg-src;
-  cargoHash = "sha256-iKjsrQ/u9SwQZNlSMPjJOxLRSbBuE21Ae0jnJ60fKoE=";
+  cargoHash = "sha256-aAzaj78FkeY7Q74AaKBhmGAm1b0WAeylBEg3vdwiWYc=";
   meta = {
     description = "File scrambler.";
     longDescription = ''

--- a/test/test_sunnyside.sh
+++ b/test/test_sunnyside.sh
@@ -27,5 +27,20 @@ if [[ "$ccontent" != "SUCCESS" ]]; then
     exit 1
 fi
 
+make-title -c yellow "Testing sunnyside bu/rs (file)"
+echo "BACKUP_TEST" > original.txt
+sunnyside bu -t original.txt -s 4 -k u -d backup.tyz
+[[ -f backup.tyz ]] || { echo_red "bu: dest not created"; exit 1; }
+sunnyside rs -t backup.tyz -s 4 -k u -d restored.txt
+[[ "$(cat restored.txt)" == "BACKUP_TEST" ]] || { echo_red "rs: file content mismatch"; exit 1; }
+
+make-title -c yellow "Testing sunnyside bu/rs (directory)"
+mkdir -p testdir/sub
+echo "NESTED" > testdir/sub/file.txt
+sunnyside bu -t testdir -s 4 -k u -d dir_backup.tyz
+[[ -f dir_backup.tyz ]] || { echo_red "bu: dir dest not created"; exit 1; }
+sunnyside rs -t dir_backup.tyz -s 4 -k u -d testdir_restored
+[[ "$(cat testdir_restored/sub/file.txt)" == "NESTED" ]] || { echo_red "rs: dir content mismatch"; exit 1; }
+
 # Cleanup
 rm -rf "$tmpdir"


### PR DESCRIPTION
## Summary

- Updates `sunnyside` flake input to `dev/ssbu` branch (0.2.0) pending merge of [goromal/sunnyside#1](https://github.com/goromal/sunnyside/pull/1)
  - https://github.com/goromal/sunnyside/pull/1
- Refreshes `cargoHash` for new dependencies (`gzp`, `flate2`, `tar`, `indicatif`)
- Adds file and directory bu/rs round-trip regression tests to `test/test_sunnyside.sh`

## Test plan

- [x] `nix build .#sunnyside` builds cleanly with correct cargoHash
- [x] `nix-shell test/shell.nix --run "cd test && bash test_sunnyside.sh"` exits 0 with no red output
- [x] Existing sunnyside/sread/swrite tests still pass

> **Note:** Once goromal/sunnyside#1 merges to `main`, the flake input in `flake.nix` should be updated from `github:goromal/sunnyside/dev/ssbu` back to `github:goromal/sunnyside` and `flake.lock` refreshed.