### PR TITLE
Add Navidrome music server to ATS

### DIFF
--- a/changes/pr-563.md
+++ b/changes/pr-563.md
@@ -1,0 +1,1 @@
+Add Navidrome music server to ATS

--- a/docs/src/machines.md
+++ b/docs/src/machines.md
@@ -415,6 +415,89 @@ Vikunja is served through nginx as a reverse proxy with HTTPS support:
 
 The nixpkgs Vikunja frontend is built with `/vikunja/` as the hardcoded API base path, so we serve the frontend on port 3457 while also proxying `/vikunja/` on ports 80/443 for API access. Both HTTP and HTTPS are supported without forced redirects.
 
+## Navidrome Music Server (ATS Only)
+
+ATS machines automatically include [Navidrome](https://www.navidrome.org/), a self-hosted music streaming server compatible with the [Subsonic API](https://www.navidrome.org/docs/developers/subsonic-api/).
+
+### Accessing Navidrome
+
+Once your ATS machine is running, Navidrome's web UI is accessible at:
+- **Web UI (HTTPS)**: `https://ats.local/navidrome/`
+- **Web UI (HTTP)**: `http://ats.local/navidrome/`
+
+It is served through nginx as a reverse proxy on the default ports (80/443) under the `/navidrome` path. The web UI is mobile-friendly.
+
+**Note**: For HTTPS access to work without certificate warnings, you need to install the SSL certificate on your client devices. See the [Local SSL Setup](#local-ssl-setup-for-https-access) section above.
+
+### Initial Setup
+
+On your **first visit** to `https://ats.local/navidrome/`, Navidrome prompts you to create an admin account. Create it, then log in. (There is no separate registration step — the first account becomes the administrator.)
+
+### Adding Music
+
+**Navidrome has no upload button in its web UI** — it is a streaming server that *scans a folder* for music. To add songs you copy files into the music folder on the server, then let Navidrome scan them.
+
+The music folder is `~/data/navidrome/music` on ATS (owned by `andrew:dev`). Copy files into it however is convenient, for example:
+
+```bash
+# From your local machine, copy an album or directory over:
+rsync -av "My Album/" andrew@ats.local:~/data/navidrome/music/
+
+# Or a single file:
+scp song.flac andrew@ats.local:~/data/navidrome/music/
+```
+
+Navidrome automatically rescans the folder on a schedule and picks up new files; you can also force an immediate scan from the web UI under **Settings → (gear menu) → Quick Scan / Full Scan**. Supported formats include MP3, FLAC, OGG, M4A/AAC, WAV, and more — metadata (artist/album/track/cover art) is read from the files' tags.
+
+> **Don't add music via the cloud copy.** `~/data` is mirrored to `box:data`, but the nightly backup runs `rcrsync override data navidrome` (local → cloud, overwriting the cloud copy). Files added to the cloud side would be wiped on the next backup. Always add music to the folder on the server itself.
+
+### Connecting Third-Party Client Apps
+
+Because Navidrome implements the **Subsonic API**, you can stream your library from any Subsonic-compatible app instead of (or in addition to) the web UI. Popular clients:
+
+- **Android**: [Symfonium](https://symfonium.app/), [DSub](https://f-droid.org/packages/github.daneren2005.dsub/), [Substreamer](https://substreamerapp.com/), [Tempo](https://github.com/CappielloAntonio/tempo)
+- **iOS**: [play:Sub](https://michaelsapps.dk/playsubapp/), [substreamer](https://substreamerapp.com/), [Amperfy](https://github.com/BLeeEZ/amperfy)
+- **Desktop / cross-platform**: [Feishin](https://github.com/jeffvli/feishin), [Sonixd](https://github.com/jeffvli/sonixd), [Supersonic](https://github.com/dweymouth/supersonic)
+
+In the client, add a new **Subsonic / Navidrome server** with these settings:
+
+| Setting | Value |
+|---|---|
+| **Server URL / Address** | `http://ats.local/navidrome` (or `https://ats.local/navidrome`) |
+| **Username** | your Navidrome account username |
+| **Password** | your Navidrome account password |
+
+Notes:
+- Use the base URL **including the `/navidrome` path** — the client appends the Subsonic `/rest/` endpoints itself (the API lives at `http://ats.local/navidrome/rest/`).
+- If you use the `https://` URL, the device must trust the ATS self-signed certificate (see [Local SSL Setup](#local-ssl-setup-for-https-access)); the `http://` URL works without it on the LAN.
+- `ats.local` is resolved via mDNS, so the client must be on the same LAN as the ATS machine (or have the hostname otherwise reachable).
+
+### Data Location
+
+- **Music library**: `~/data/navidrome/music/`
+- **Database & cache**: `~/data/navidrome/` (Navidrome's `navidrome.db` and cache live here)
+
+Both the data folder and the music folder live under `~/data` so they are included in the daily cloud backup.
+
+### Backup
+
+The Navidrome data directory is automatically backed up daily at midnight by the `ats-navidrome-backup` orchestrator job, which syncs `~/data/navidrome` to cloud storage via `rcrsync override data navidrome`.
+
+You can manually trigger a backup with:
+
+```bash
+ssh andrew@ats.local
+sudo systemctl start ats-navidrome-backup.service
+```
+
+### Architecture
+
+Navidrome is served through nginx as a reverse proxy:
+- Runs as the `andrew:dev` user (so the music/data folders live in `~/data` and remain readable by the backup job)
+- Internal service listens on `127.0.0.1:4533` (centrally managed in `service-ports.nix`)
+- Started with `--baseurl /navidrome` so all URLs are served under the `/navidrome` subpath, proxied on ports 80/443
+- SSL certificates: same self-signed certificates as the main web server (`~/secrets/vpn/`)
+
 ## Video Downloader (ATS Only)
 
 ATS machines include a web UI for downloading videos from YouTube, TikTok, and any other site supported by [yt-dlp](https://github.com/yt-dlp/yt-dlp). Accessible at `https://ats.local/videodl/`.

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "anixdata": {
       "flake": false,
       "locked": {
-        "lastModified": 1782103454,
-        "narHash": "sha256-JLZcjOzYPKFnSI3NKQI10/9kVcPSB7qwGq7/pV89JVA=",
+        "lastModified": 1782673411,
+        "narHash": "sha256-jdzSEzxVzwhoAmQ0gQCfC/0qyTuekZIzuhxmUIEOTTc=",
         "owner": "goromal",
         "repo": "anixdata",
-        "rev": "bc7d2248aa6dc581f72a6ecb0628596d5462bb73",
+        "rev": "735ffeff84c9cafde97de17927e1f6b5524ce831",
         "type": "github"
       },
       "original": {

--- a/pkgs/modules/navidrome/module.nix
+++ b/pkgs/modules/navidrome/module.nix
@@ -1,0 +1,91 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with import ../../nixos/dependencies.nix;
+let
+  cfg = config.services.navidrome-ats;
+in
+{
+  options.services.navidrome-ats = {
+    enable = lib.mkEnableOption "enable Navidrome music server";
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The navidrome package to use";
+      default = pkgs.navidrome;
+    };
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      description = "Data directory for the database and cache";
+      default = "/data/andrew/data/navidrome";
+    };
+    musicDir = lib.mkOption {
+      type = lib.types.str;
+      description = "Directory Navidrome scans for music";
+      default = "${cfg.dataDir}/music";
+    };
+    port = lib.mkOption {
+      type = lib.types.port;
+      description = "Port to run the server on";
+      default = service-ports.navidrome;
+    };
+    subdomain = lib.mkOption {
+      type = lib.types.str;
+      description = "Subdomain path for reverse proxy";
+      default = "/navidrome";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    machines.base.webServices = [
+      {
+        name = "Navidrome";
+        path = "${cfg.subdomain}/";
+        description = "Personal music streaming server";
+        icon = "music";
+        faviconSvg = anixpkgs.pkgData.icons.favicons."music".data;
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 andrew dev -"
+      "d ${cfg.musicDir} 0755 andrew dev -"
+    ];
+
+    systemd.services.navidrome-ats = {
+      enable = true;
+      description = "Navidrome Music Server";
+      after = [ "network.target" ];
+      unitConfig = {
+        StartLimitIntervalSec = 0;
+      };
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/navidrome --datafolder ${cfg.dataDir} --musicfolder ${cfg.musicDir} --address 127.0.0.1 --port ${builtins.toString cfg.port} --baseurl ${cfg.subdomain}";
+        WorkingDirectory = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
+        Restart = "always";
+        RestartSec = 5;
+        User = "andrew";
+        Group = "dev";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    machines.base.runWebServer = true;
+    services.nginx.virtualHosts."${config.networking.hostName}.local" = {
+      locations."${cfg.subdomain}/" = {
+        proxyPass = "http://127.0.0.1:${builtins.toString cfg.port}${cfg.subdomain}/";
+        proxyWebsockets = true;
+        extraConfig = ''
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        '';
+      };
+    };
+  };
+}

--- a/pkgs/nixos/pc-base.nix
+++ b/pkgs/nixos/pc-base.nix
@@ -246,6 +246,7 @@ in
     ../modules/mailNode/module.nix
     ../modules/vikunja/module.nix
     ../modules/vikunja-mcp/module.nix
+    ../modules/navidrome/module.nix
     ../modules/notion-mcp/module.nix
     ../modules/wiki-mcp/module.nix
     ../modules/jupyter-mcp/module.nix
@@ -476,6 +477,11 @@ in
       services.la-quiz-web = {
         enable = cfg.isATS;
         dataDir = "${cfg.homeDir}/data/la-quiz-web";
+      };
+
+      services.navidrome-ats = {
+        enable = cfg.isATS;
+        dataDir = "${cfg.homeDir}/data/navidrome";
       };
 
       services.tester = {

--- a/pkgs/nixos/profiles/ats.nix
+++ b/pkgs/nixos/profiles/ats.nix
@@ -174,6 +174,17 @@ in
           };
         }
         {
+          name = "ats-navidrome-backup";
+          jobShellScript = pkgs.writeShellScript "ats-navidrome-backup" ''
+            rcrsync override data navidrome || { logger -t ats-navidrome-backup "Navidrome Backup UNSUCCESSFUL"; >&2 echo "backup error!"; exit 1; }
+            logger -t ats-navidrome-backup "Navidrome backup successful!"
+          '';
+          timerCfg = {
+            OnCalendar = [ "*-*-* 00:00:00" ];
+            Persistent = false;
+          };
+        }
+        {
           name = "ats-la-quiz-backup";
           jobShellScript = pkgs.writeShellScript "ats-la-quiz-backup" ''
             rcrsync override data la-quiz-web || { logger -t authm "LA Quiz Backup UNSUCCESSFUL"; >&2 echo "backup error!"; exit 1; }

--- a/pkgs/nixos/service-ports.nix
+++ b/pkgs/nixos/service-ports.nix
@@ -24,6 +24,7 @@
     internal = 3456;
     public = 3457;
   };
+  navidrome = 4533;
   la-quiz-web = 5656;
   tester = 5757;
   disciple = 6363;


### PR DESCRIPTION
Adds a navidrome-ats NixOS module that runs Navidrome as andrew:dev with its data and music folders under ~/data/navidrome, reverse-proxied by nginx under the /navidrome subpath. Includes a daily ats-navidrome-backup orchestrator job (rcrsync override data navidrome), a service port entry, and docs in machines.md covering how to add songs and connect Subsonic clients. flake.lock bumped to pull the new music icon from anixdata.