### PR TITLE
Add on-disk blacklist for orchestrator jobs

### DIFF
--- a/changes/pr-565.md
+++ b/changes/pr-565.md
@@ -1,0 +1,1 @@
+Add on-disk blacklist for orchestrator jobs

--- a/pkgs/nixos/pc-base.nix
+++ b/pkgs/nixos/pc-base.nix
@@ -938,36 +938,57 @@ in
             }
           );
     }
-    {
-      systemd.timers = builtins.listToAttrs (
-        map (job: {
-          name = job.name;
-          value = {
-            description = "${job.name} trigger timer";
-            wantedBy = [ "timers.target" ];
-            timerConfig = job.timerCfg // {
-              Unit = "${job.name}.service";
+    (
+      let
+        # On-disk blacklist: a marker file named after a job in this directory
+        # causes that job's oneshot service to fail immediately instead of
+        # submitting to orchestratord. Managed via the orchestrator UI.
+        orchBlacklistDir = "${cfg.homeDir}/configs/orchestrator-blacklist.d";
+        orchJobGuard = pkgs.writeShellScript "orch-job-guard" ''
+          name="$1"
+          if [ -e "${orchBlacklistDir}/$name" ]; then
+            ${pkgs.util-linux}/bin/logger -t orchestrator "Job '$name' is blacklisted; refusing to run"
+            echo "Orchestrator job '$name' is blacklisted by ${orchBlacklistDir}/$name" >&2
+            exit 1
+          fi
+        '';
+      in
+      {
+        systemd.tmpfiles.rules = [
+          "d ${orchBlacklistDir} 0775 andrew dev -"
+        ];
+        systemd.timers = builtins.listToAttrs (
+          map (job: {
+            name = job.name;
+            value = {
+              description = "${job.name} trigger timer";
+              wantedBy = [ "timers.target" ];
+              timerConfig = job.timerCfg // {
+                Unit = "${job.name}.service";
+              };
             };
-          };
-        }) cfg.timedOrchJobs
-      );
-      systemd.services = builtins.listToAttrs (
-        map (job: {
-          name = job.name;
-          value = {
-            enable = true;
-            description = "${job.name} oneshot service";
-            serviceConfig = {
-              Type = "oneshot";
-              ExecStart = "${anixpkgs.orchestrator}/bin/orchestrator bash 'bash ${job.jobShellScript}'";
-              ReadWritePaths = job.readWritePaths or [ "/" ];
-            }
-            // (lib.optionalAttrs ((job.execStartPre or null) != null) {
-              ExecStartPre = job.execStartPre;
-            });
-          };
-        }) cfg.timedOrchJobs
-      );
-    }
+          }) cfg.timedOrchJobs
+        );
+        systemd.services = builtins.listToAttrs (
+          map (job: {
+            name = job.name;
+            value = {
+              enable = true;
+              description = "${job.name} oneshot service";
+              serviceConfig = {
+                Type = "oneshot";
+                ExecStart = "${anixpkgs.orchestrator}/bin/orchestrator bash 'bash ${job.jobShellScript}'";
+                ReadWritePaths = job.readWritePaths or [ "/" ];
+                # Blacklist guard runs first for every job, then any
+                # job-specific ExecStartPre.
+                ExecStartPre =
+                  [ "${orchJobGuard} ${job.name}" ]
+                  ++ lib.optionals ((job.execStartPre or null) != null) (lib.toList job.execStartPre);
+              };
+            };
+          }) cfg.timedOrchJobs
+        );
+      }
+    )
   ];
 }

--- a/pkgs/nixos/pc-base.nix
+++ b/pkgs/nixos/pc-base.nix
@@ -981,9 +981,10 @@ in
                 ReadWritePaths = job.readWritePaths or [ "/" ];
                 # Blacklist guard runs first for every job, then any
                 # job-specific ExecStartPre.
-                ExecStartPre =
-                  [ "${orchJobGuard} ${job.name}" ]
-                  ++ lib.optionals ((job.execStartPre or null) != null) (lib.toList job.execStartPre);
+                ExecStartPre = [
+                  "${orchJobGuard} ${job.name}"
+                ]
+                ++ lib.optionals ((job.execStartPre or null) != null) (lib.toList job.execStartPre);
               };
             };
           }) cfg.timedOrchJobs

--- a/pkgs/python-packages/flasks/orchestrator_ui/module.nix
+++ b/pkgs/python-packages/flasks/orchestrator_ui/module.nix
@@ -39,7 +39,7 @@ in
       };
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${cfg.package}/bin/orchestrator_ui --subdomain /orchestrator --port ${builtins.toString service-ports.orchestrator_ui} --orch-port ${builtins.toString service-ports.orchestrator}${
+        ExecStart = "${cfg.package}/bin/orchestrator_ui --subdomain /orchestrator --port ${builtins.toString service-ports.orchestrator_ui} --orch-port ${builtins.toString service-ports.orchestrator} --blacklist-dir ${globalCfg.homeDir}/configs/orchestrator-blacklist.d${
           lib.optionalString (serviceList != "") " --services ${serviceList}"
         }";
         Restart = "always";

--- a/pkgs/python-packages/flasks/orchestrator_ui/orchestrator_ui.py
+++ b/pkgs/python-packages/flasks/orchestrator_ui/orchestrator_ui.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import subprocess
 
 import grpc
@@ -15,9 +16,16 @@ parser.add_argument("--services", type=str, default="",
                     help="Slash-separated list of service names")
 parser.add_argument("--orch-port", type=int, default=40040,
                     help="orchestratord gRPC port")
+parser.add_argument("--blacklist-dir", type=str, default="",
+                    help="Directory of job-name marker files that blacklist jobs")
 args = parser.parse_args()
 
 services = [s for s in args.services.split("/") if s]
+
+# Map each service unit ("<job>.service") to its bare job name, which is what
+# the on-disk blacklist marker files and the orchestrator guard use.
+JOB_NAMES = {svc: svc[:-len(".service")] if svc.endswith(".service") else svc
+             for svc in services}
 
 app = Flask(__name__)
 bp = Blueprint('orchestrator', __name__, url_prefix=args.subdomain)
@@ -67,7 +75,8 @@ def index():
     statuses = {svc: get_service_state(svc) for svc in services}
     orch_state = get_service_state('orchestratord')
     return render_template('main.html', services=services, statuses=statuses,
-                           orch_state=orch_state, subdomain=args.subdomain)
+                           orch_state=orch_state, subdomain=args.subdomain,
+                           job_names=JOB_NAMES)
 
 
 @bp.route('/status/<service>')
@@ -106,6 +115,43 @@ def restart(service):
         yield "data: [DONE]\n\n"
 
     return Response(stream_with_context(generate()), mimetype='text/event-stream')
+
+
+def blacklist_marker(job_name):
+    """Absolute path to a job's blacklist marker, or None if invalid/unconfigured."""
+    if not args.blacklist_dir or job_name not in JOB_NAMES.values():
+        return None
+    return os.path.join(args.blacklist_dir, job_name)
+
+
+@bp.route('/jobs/blacklist')
+def blacklist_status():
+    """Return {job_name: blacklisted_bool} for every known job."""
+    return jsonify({
+        name: (marker is not None and os.path.exists(marker))
+        for name, marker in (
+            (n, blacklist_marker(n)) for n in JOB_NAMES.values()
+        )
+    })
+
+
+@bp.route('/jobs/blacklist/<job_name>', methods=['POST', 'DELETE'])
+def blacklist_toggle(job_name):
+    from flask import request
+    marker = blacklist_marker(job_name)
+    if marker is None:
+        return jsonify({'error': 'Unknown job or blacklist not configured'}), 400
+    try:
+        if request.method == 'POST':
+            os.makedirs(args.blacklist_dir, exist_ok=True)
+            with open(marker, 'w'):
+                pass
+        else:
+            if os.path.exists(marker):
+                os.remove(marker)
+    except OSError as e:
+        return jsonify({'error': str(e)}), 500
+    return jsonify({'job': job_name, 'blacklisted': os.path.exists(marker)})
 
 
 @bp.route('/jobs/summary')

--- a/pkgs/python-packages/flasks/orchestrator_ui/templates/main.html
+++ b/pkgs/python-packages/flasks/orchestrator_ui/templates/main.html
@@ -73,12 +73,15 @@
                 {{ state }}
               </span>
             </div>
-            <div class="d-flex gap-2">
+            <div class="d-flex gap-2 align-items-center">
               <button class="btn btn-sm btn-primary"
                 onclick="triggerRestart('{{ svc }}', {{ loop.index }})"
                 id="btn-{{ loop.index }}">Restart</button>
               <button class="btn btn-sm btn-outline-secondary"
                 onclick="refreshStatus('{{ svc }}', {{ loop.index }})">Refresh</button>
+              <button class="btn btn-sm btn-outline-danger ms-auto"
+                id="blk-{{ loop.index }}" data-job="{{ job_names[svc] }}"
+                onclick="toggleBlacklist('{{ job_names[svc] }}', {{ loop.index }})">Blacklist</button>
             </div>
             <div id="log-{{ loop.index }}" class="log-box mt-2"></div>
           </div>
@@ -155,6 +158,42 @@ function triggerRestart(service, idx) {
     btn.textContent = 'Restart';
     refreshStatus(service, idx);
   });
+}
+
+// ── Blacklist controls ──────────────────────────────────────────────────────
+
+function applyBlacklistState(idx, blacklisted) {
+  const blk = document.getElementById('blk-' + idx);
+  const restart = document.getElementById('btn-' + idx);
+  if (!blk) return;
+  blk.textContent = blacklisted ? 'Allow' : 'Blacklist';
+  blk.className = 'btn btn-sm ms-auto ' + (blacklisted ? 'btn-danger' : 'btn-outline-danger');
+  if (restart) {
+    restart.disabled = blacklisted;
+    restart.title = blacklisted ? 'Job is blacklisted' : '';
+  }
+}
+
+function refreshBlacklist() {
+  fetch(subdomain + '/jobs/blacklist')
+    .then(r => r.json())
+    .then(data => {
+      document.querySelectorAll('[id^="blk-"]').forEach(btn => {
+        applyBlacklistState(btn.id.slice(4), !!data[btn.dataset.job]);
+      });
+    })
+    .catch(() => {});
+}
+
+function toggleBlacklist(jobName, idx) {
+  const blk = document.getElementById('blk-' + idx);
+  const method = blk.textContent.trim() === 'Allow' ? 'DELETE' : 'POST';
+  blk.disabled = true;
+  fetch(subdomain + '/jobs/blacklist/' + encodeURIComponent(jobName), { method })
+    .then(r => r.json())
+    .then(data => applyBlacklistState(idx, !!data.blacklisted))
+    .catch(() => {})
+    .finally(() => { blk.disabled = false; });
 }
 
 // ── Streaming helper ────────────────────────────────────────────────────────
@@ -362,9 +401,11 @@ setInterval(() => {
   refreshStatus('{{ svc }}', {{ loop.index }});
   {% endfor %}
   refreshJobs();
+  refreshBlacklist();
 }, 30000);
 
 refreshJobs();
+refreshBlacklist();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Introduce a per-job blacklist managed via marker files in ~/configs/orchestrator-blacklist.d/. A marker named after a timed orchestrator job causes that job's oneshot service to fail immediately at ExecStartPre, before it is ever submitted to orchestratord — covering both timer-fired and manually-triggered runs.

Wiring lives entirely in the timedOrchJobs generator (pc-base.nix), so every current and future job inherits the guard for free with no per-job changes. The orchestrator UI gains a Blacklist/Allow toggle per job, backed by GET /jobs/blacklist and POST/DELETE /jobs/blacklist/<name>.