### PR TITLE
[web] Overhaul rankserver (Preferences) UI to match stampserver

### DIFF
--- a/changes/pr-566.md
+++ b/changes/pr-566.md
@@ -1,0 +1,1 @@
+[web] Overhaul rankserver (Preferences) UI to match stampserver

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "anixdata": {
       "flake": false,
       "locked": {
-        "lastModified": 1782712381,
-        "narHash": "sha256-/seh3BIn+GZHe8brZgyTgsSCZCSCoEJonAvzgSlvWJQ=",
+        "lastModified": 1782792871,
+        "narHash": "sha256-NCe97BA+nohmymtCmG+PlcAgwm8k6Qjo/TwysbXasyE=",
         "owner": "goromal",
         "repo": "anixdata",
-        "rev": "96cc50acd1598c9c616ab79e8a036c22bf145f5f",
+        "rev": "fb93ef5df1b61a27f4ad65bed9a5802db7042a24",
         "type": "github"
       },
       "original": {

--- a/pkgs/python-packages/flasks/rankserver/default.nix
+++ b/pkgs/python-packages/flasks/rankserver/default.nix
@@ -7,6 +7,7 @@
   wtforms,
   werkzeug,
   pysorting,
+  pillow,
   strings,
   redirects,
   writeTextFile,
@@ -35,6 +36,7 @@ buildPythonPackage rec {
     wtforms
     werkzeug
     pysorting
+    pillow
   ];
   meta = {
     description = "A portable webserver for ranking files via binary manual comparisons, powered by Python's flask library.";

--- a/pkgs/python-packages/flasks/rankserver/index.html
+++ b/pkgs/python-packages/flasks/rankserver/index.html
@@ -1,23 +1,433 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
-    <title>Rank Server</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Preferences</title>
     <style>
-        img {
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f8f9fa;
+            color: #212529;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 15px;
+        }
+
+        nav {
+            background-color: #224abe;
+            padding: 15px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+
+        nav ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            justify-content: flex-end;
+            gap: 6px;
+        }
+
+        nav li { margin: 0; }
+
+        nav a {
+            color: #fff;
+            text-decoration: none;
+            padding: 10px 20px;
+            display: block;
+            border-radius: 5px;
+            transition: background-color 0.2s;
+            font-weight: 500;
+        }
+
+        nav a:hover { background-color: #1e3a8a; }
+
+        h1 {
+            color: #212529;
+            margin: 20px 0;
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+
+        @media (min-width: 768px) {
+            h1 { font-size: 2rem; }
+        }
+
+        .btn {
+            padding: 14px 24px;
+            margin: 0;
+            cursor: pointer;
+            background-color: #4e73df;
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-size: 1rem;
+            font-weight: 500;
+            transition: background-color 0.2s ease, box-shadow 0.2s ease;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            min-height: 48px;
+            touch-action: manipulation;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .btn:hover {
+            background-color: #2e59d9;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+        }
+
+        .btn:active { opacity: 0.85; }
+
+        .btn-danger { background-color: #e74a3b; }
+        .btn-danger:hover { background-color: #d32f2f; }
+
+        .btn-sm {
+            padding: 8px 16px;
+            min-height: 36px;
+            font-size: 0.9rem;
+        }
+
+        .status-message {
+            padding: 16px 20px;
+            margin: 20px 0;
+            border-radius: 8px;
+            display: none;
+            font-size: 1rem;
+            font-weight: 500;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+        }
+
+        .status-success {
+            background-color: #d4edda;
+            color: #155724;
+            border: 2px solid #c3e6cb;
+        }
+
+        .status-error {
+            background-color: #f8d7da;
+            color: #721c24;
+            border: 2px solid #f5c6cb;
+        }
+
+        .error-message {
+            background-color: #fff3cd;
+            color: #856404;
+            border: 2px solid #ffeaa7;
+            padding: 20px;
+            border-radius: 8px;
+            margin: 20px 0;
+            font-size: 1rem;
+        }
+
+        /* ===== Comparison ===== */
+        .compare-prompt {
+            color: #495057;
+            font-size: 1.05rem;
+            font-weight: 500;
+            margin: 0 0 16px 0;
+        }
+
+        .compare-row {
+            display: flex;
+            gap: 20px;
+            flex-wrap: wrap;
+            margin: 20px 0;
+        }
+
+        .compare-card {
+            flex: 1;
+            min-width: 260px;
+            background-color: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .compare-media {
             width: 100%;
-            max-width: 300px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
 
-        .column {
-            float: left;
-            width: 50%;
+        .compare-media img {
+            width: 100%;
+            height: auto;
+            max-width: 100%;
+            border-radius: 8px;
         }
 
-        .row:after {
-            content: "";
-            display: table;
-            clear: both;
+        .txt-name {
+            font-family: monospace;
+            font-size: 1.1rem;
+            font-weight: 700;
+            color: #212529;
+            word-break: break-all;
+            text-align: center;
+            padding: 40px 10px;
+        }
+
+        .compare-card form { margin: 0; width: 100%; }
+
+        .choose-btn {
+            width: 100%;
+            padding: 16px 24px;
+            font-size: 1.1rem;
+            font-weight: 600;
+            background-color: #1cc88a;
+            color: white;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            min-height: 56px;
+            touch-action: manipulation;
+        }
+
+        .choose-btn:hover {
+            background-color: #17a673;
+            transform: translateY(-1px);
+            box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+        }
+
+        .choose-btn:active { transform: translateY(0); }
+
+        @media (max-width: 600px) {
+            .compare-row { flex-direction: column; }
+        }
+
+        /* ===== Done banner ===== */
+        .done-banner {
+            background-color: #d4edda;
+            color: #155724;
+            border: 2px solid #c3e6cb;
+            padding: 20px;
+            border-radius: 12px;
+            margin: 20px 0;
+            font-size: 1.1rem;
+            font-weight: 600;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+
+        .done-banner form { margin: 16px 0 0 0; }
+
+        /* ===== Ranked list ===== */
+        .rank-list {
+            background-color: #ffffff;
+            padding: 25px;
+            border-radius: 12px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            margin: 30px 0;
+        }
+
+        .rank-list h2 {
+            margin: 0 0 20px 0;
+            color: #495057;
+            font-size: 1.5rem;
+            font-weight: 600;
+            border-bottom: 2px solid #e9ecef;
+            padding-bottom: 10px;
+        }
+
+        .rank-list ol {
+            margin: 0;
+            padding-left: 0;
+            list-style: none;
+            counter-reset: rank;
+        }
+
+        .rank-list li {
+            counter-increment: rank;
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            padding: 12px 8px;
+            border-bottom: 1px solid #e9ecef;
+        }
+
+        .rank-list li:last-child { border-bottom: none; }
+
+        .rank-list li::before {
+            content: counter(rank);
+            flex-shrink: 0;
+            width: 34px;
+            height: 34px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: #4e73df;
+            color: white;
+            border-radius: 50%;
+            font-size: 0.9rem;
+            font-weight: 700;
+        }
+
+        .rank-list img {
+            max-width: 120px;
+            height: auto;
+            border-radius: 6px;
+        }
+
+        .rank-list .rank-txt {
+            font-family: monospace;
+            font-weight: 600;
+            color: #212529;
+            word-break: break-all;
+        }
+
+        /* ===== Directory config (intro) ===== */
+        .rankables-config {
+            margin: 20px 0;
+            padding: 20px;
+            background-color: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+
+        .rankables-config h2 {
+            font-size: 1.2rem;
+            font-weight: 600;
+            color: #495057;
+            margin: 0 0 14px 0;
+        }
+
+        .rankables-config p.help {
+            color: #6c757d;
+            font-size: 0.95rem;
+            margin: 0 0 16px 0;
+        }
+
+        .rankables-realpath {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            flex-wrap: wrap;
+        }
+
+        .realpath-label {
+            font-size: 0.9rem;
+            color: #6c757d;
+            font-weight: 500;
+        }
+
+        .realpath-value {
+            font-family: monospace;
+            font-size: 0.95rem;
+            color: #212529;
+            background: #f1f3f5;
+            padding: 6px 12px;
+            border-radius: 6px;
+            flex: 1;
+            word-break: break-all;
+        }
+
+        .dir-picker {
+            margin-top: 16px;
+            border: 2px solid #e9ecef;
+            border-radius: 10px;
+            overflow: hidden;
+        }
+
+        .dir-picker-header {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 14px;
+            background: #f8f9fa;
+            border-bottom: 1px solid #e9ecef;
+            flex-wrap: wrap;
+        }
+
+        .dir-picker-path {
+            font-family: monospace;
+            font-size: 0.9rem;
+            color: #495057;
+            flex: 1;
+            word-break: break-all;
+        }
+
+        .dir-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            max-height: 260px;
+            overflow-y: auto;
+        }
+
+        .dir-list li + li {
+            border-top: 1px solid #f1f3f5;
+        }
+
+        .dir-btn {
+            width: 100%;
+            padding: 10px 16px;
+            text-align: left;
+            background: none;
+            border: none;
+            cursor: pointer;
+            font-size: 0.95rem;
+            color: #212529;
+            transition: background-color 0.15s;
+            touch-action: manipulation;
+        }
+
+        .dir-btn:hover { background-color: #e9f0ff; }
+        .dir-btn:active { background-color: #d0e0ff; }
+
+        .dir-btn::before {
+            content: '📁 ';
+            font-size: 0.9rem;
+        }
+
+        .dir-picker-actions {
+            display: flex;
+            gap: 10px;
+            padding: 12px 14px;
+            background: #f8f9fa;
+            border-top: 1px solid #e9ecef;
+            flex-wrap: wrap;
+        }
+
+        .dir-picker-actions .btn {
+            flex: 1;
+            min-width: 100px;
+        }
+
+        .start-row {
+            margin: 24px 0;
+        }
+
+        .start-btn {
+            display: inline-flex;
+            padding: 16px 32px;
+            font-size: 1.1rem;
+            font-weight: 600;
+            background-color: #1cc88a;
+        }
+
+        .start-btn:hover { background-color: #17a673; }
+
+        @media (max-width: 767px) {
+            .container { padding: 10px; }
+            h1 { font-size: 1.25rem; }
         }
     </style>
 </head>
@@ -25,59 +435,199 @@
 <body>
     <nav>
         <ul>
+            {% if not intro %}
+            <li><a href="{{ urlroot }}intro">Directory</a></li>
+            {% endif %}
             <li><a href="{{ urlroot }}logout">Logout</a></li>
         </ul>
     </nav>
-    <h1>Rank Server</h1>
-    {% if err %}
-    <p>Server returned error:</p>
-    <p>{{ msg }}</p>
-    {% else %}
-    {% if done %}
-    <p>Sorting complete!</p>
-    <form action="{{ urlroot }}" method="POST">
-        <input type="submit" name="refine" value="Refine Rankings" />
-    </form>
-    {% else %}
-    <div class="row">
-        <div class="column">
-            {% if l.endswith('.txt') %}
-            <b>{{ l }}</b>
-            {% else %}
-            <img src="{{ urlroot }}{{ l }}" sizes="(max-width: 500px) 100vw, (max-width: 900px) 50vw, 800px" alt="" />
-            {% endif %}
-            <br>
+
+    <div class="container">
+        <h1>Preferences: {{ datadir }}</h1>
+
+        <div id="statusMessage" class="status-message"></div>
+
+        {% if intro %}
+        <div class="rankables-config">
+            <h2>Rankables Directory</h2>
+            <p class="help">Choose where the <code>rankables</code> symlink should point. The selected
+               directory's files (<code>.txt</code> / <code>.png</code>) become the items you rank.</p>
+            <div class="rankables-realpath">
+                <span class="realpath-label">Current real path:</span>
+                <span class="realpath-value" id="rankablesRealPath">Loading...</span>
+                <button class="btn btn-sm" onclick="openDirPicker()">Change&hellip;</button>
+            </div>
+            <div class="dir-picker" id="dirPicker" style="display: none;">
+                <div class="dir-picker-header">
+                    <span class="dir-picker-path" id="pickerCurrentPath"></span>
+                    <button class="btn btn-sm" onclick="pickerNavigateUp()">&#8593; Up</button>
+                </div>
+                <ul class="dir-list" id="dirList"></ul>
+                <div class="dir-picker-actions">
+                    <button class="btn btn-sm btn-danger" onclick="closeDirPicker()">Cancel</button>
+                    <button class="btn btn-sm" onclick="selectPickerDir()">Select This Directory</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="start-row">
+            <a href="{{ urlroot }}" class="btn start-btn">Start Ranking &rarr;</a>
+        </div>
+
+        {% else %}
+        {% if err %}
+        <div class="error-message">{{ msg }}</div>
+        {% else %}
+        {% if done %}
+        <div class="done-banner">
+            Sorting complete! Your ranking is shown below.
             <form action="{{ urlroot }}" method="POST">
-                <input type="submit" name="choose_l" value="Choose" />
+                <input type="submit" class="btn" name="refine" value="Refine Rankings" />
             </form>
         </div>
-        <div class="column">
-            {% if r.endswith('.txt') %}
-            <b>{{ r }}</b>
-            {% else %}
-            <img src="{{ urlroot }}{{ r }}" sizes="(max-width: 500px) 100vw, (max-width: 900px) 50vw, 800px" alt="" />
-            {% endif %}
-            <br>
-            <form action="{{ urlroot }}" method="POST">
-                <input type="submit" name="choose_r" value="Choose" />
-            </form>
+        {% else %}
+        <p class="compare-prompt">Which do you prefer?</p>
+        <div class="compare-row">
+            <div class="compare-card">
+                <div class="compare-media">
+                    {% if l.endswith('.txt') %}
+                    <span class="txt-name">{{ l }}</span>
+                    {% else %}
+                    <img src="{{ urlroot }}{{ l }}" alt="" />
+                    {% endif %}
+                </div>
+                <form action="{{ urlroot }}" method="POST">
+                    <input type="submit" class="choose-btn" name="choose_l" value="Choose" />
+                </form>
+            </div>
+            <div class="compare-card">
+                <div class="compare-media">
+                    {% if r.endswith('.txt') %}
+                    <span class="txt-name">{{ r }}</span>
+                    {% else %}
+                    <img src="{{ urlroot }}{{ r }}" alt="" />
+                    {% endif %}
+                </div>
+                <form action="{{ urlroot }}" method="POST">
+                    <input type="submit" class="choose-btn" name="choose_r" value="Choose" />
+                </form>
+            </div>
         </div>
+        {% endif %}
+
+        <div class="rank-list">
+            <h2>Current Ranking</h2>
+            <ol>
+                {% for item in rlist %}
+                <li>
+                    {% if item.endswith('.txt') %}
+                    <span class="rank-txt">{{ item }}</span>
+                    {% else %}
+                    <img src="{{ urlroot }}{{ item }}" alt="" />
+                    {% endif %}
+                </li>
+                {% endfor %}
+            </ol>
+        </div>
+        {% endif %}
+        {% endif %}
     </div>
-    {% endif %}
-    <hr>
-    <ol>
-        {% for item in rlist %}
-        <li>
-            {% if item.endswith('.txt') %}
-            <b>{{ urlroot }}{{ item }}</b>
-            {% else %}
-            <img src="{{ urlroot }}{{ item }}" sizes="(max-width: 500px) 100vw, (max-width: 900px) 50vw, 800px"
-                alt="" />
-            {% endif %}
-        </li>
-        {% endfor %}
-    </ol>
-    {% endif %}
+
+    <script>
+        function showStatus(message, isError = false) {
+            const statusDiv = document.getElementById('statusMessage');
+            statusDiv.textContent = message;
+            statusDiv.className = 'status-message ' + (isError ? 'status-error' : 'status-success');
+            statusDiv.style.display = 'block';
+            setTimeout(() => { statusDiv.style.display = 'none'; }, 5000);
+        }
+
+        // ===== RANKABLES DIR PICKER =====
+
+        {% if intro %}
+        let _pickerPath = '/';
+
+        function loadRankablesInfo() {
+            fetch('{{ urlroot }}api/rankables-info')
+                .then(r => r.json())
+                .then(data => {
+                    document.getElementById('rankablesRealPath').textContent = data.real_path;
+                    _pickerPath = data.real_path;
+                })
+                .catch(() => {
+                    document.getElementById('rankablesRealPath').textContent = '(error loading)';
+                });
+        }
+
+        function openDirPicker() {
+            document.getElementById('dirPicker').style.display = 'block';
+            loadPickerDirs(_pickerPath);
+        }
+
+        function closeDirPicker() {
+            document.getElementById('dirPicker').style.display = 'none';
+        }
+
+        function loadPickerDirs(path) {
+            fetch('{{ urlroot }}api/list-dirs', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({path: path})
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.error) { showStatus('Error: ' + data.error, true); return; }
+                _pickerPath = data.path;
+                document.getElementById('pickerCurrentPath').textContent = data.path;
+                const list = document.getElementById('dirList');
+                list.innerHTML = '';
+                data.dirs.forEach(dir => {
+                    const li = document.createElement('li');
+                    const btn = document.createElement('button');
+                    btn.className = 'dir-btn';
+                    btn.textContent = dir;
+                    const fullPath = data.path === '/' ? '/' + dir : data.path + '/' + dir;
+                    btn.onclick = () => loadPickerDirs(fullPath);
+                    li.appendChild(btn);
+                    list.appendChild(li);
+                });
+            })
+            .catch(err => showStatus('Error: ' + err.message, true));
+        }
+
+        function pickerNavigateUp() {
+            fetch('{{ urlroot }}api/list-dirs', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({path: _pickerPath})
+            })
+            .then(r => r.json())
+            .then(data => { if (data.parent) loadPickerDirs(data.parent); });
+        }
+
+        function selectPickerDir() {
+            if (!confirm('Set rankables directory to:\n' + _pickerPath)) return;
+            fetch('{{ urlroot }}api/set-rankables-dir', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({path: _pickerPath})
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    closeDirPicker();
+                    document.getElementById('rankablesRealPath').textContent = data.real_path;
+                    showStatus('Rankables directory updated to: ' + data.real_path);
+                } else {
+                    showStatus('Error: ' + (data.error || 'Unknown error'), true);
+                }
+            })
+            .catch(err => showStatus('Error: ' + err.message, true));
+        }
+
+        loadRankablesInfo();
+        {% endif %}
+    </script>
 </body>
 
 </html>

--- a/pkgs/python-packages/flasks/rankserver/index.html
+++ b/pkgs/python-packages/flasks/rankserver/index.html
@@ -497,7 +497,7 @@
                     {% if l.endswith('.txt') %}
                     <span class="txt-name">{{ l }}</span>
                     {% else %}
-                    <img src="{{ urlroot }}{{ l }}" alt="" />
+                    <img src="{{ urlroot }}thumb/{{ l }}?w=1200" decoding="async" alt="" />
                     {% endif %}
                 </div>
                 <form action="{{ urlroot }}" method="POST">
@@ -509,7 +509,7 @@
                     {% if r.endswith('.txt') %}
                     <span class="txt-name">{{ r }}</span>
                     {% else %}
-                    <img src="{{ urlroot }}{{ r }}" alt="" />
+                    <img src="{{ urlroot }}thumb/{{ r }}?w=1200" decoding="async" alt="" />
                     {% endif %}
                 </div>
                 <form action="{{ urlroot }}" method="POST">
@@ -527,7 +527,7 @@
                     {% if item.endswith('.txt') %}
                     <span class="rank-txt">{{ item }}</span>
                     {% else %}
-                    <img src="{{ urlroot }}{{ item }}" alt="" />
+                    <img src="{{ urlroot }}thumb/{{ item }}?w=240" loading="lazy" decoding="async" alt="" />
                     {% endif %}
                 </li>
                 {% endfor %}

--- a/pkgs/python-packages/flasks/rankserver/index.html
+++ b/pkgs/python-packages/flasks/rankserver/index.html
@@ -161,13 +161,16 @@
         }
 
         .compare-media {
+            /* Plain block flow, NOT flex: a replaced <img> used as a direct flex
+               item with height:auto can fail to reserve its aspect-ratio height in
+               WebKit, collapsing the container so the image overflows and overlaps
+               the ranked list below. Mirrors stampserver's .image-container. */
             width: 100%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
+            text-align: center;
         }
 
         .compare-media img {
+            display: block;
             width: 100%;
             height: auto;
             max-width: 100%;
@@ -175,6 +178,7 @@
         }
 
         .txt-name {
+            display: block;
             font-family: monospace;
             font-size: 1.1rem;
             font-weight: 700;

--- a/pkgs/python-packages/flasks/rankserver/login.html
+++ b/pkgs/python-packages/flasks/rankserver/login.html
@@ -5,39 +5,147 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Login</title>
+    <title>Login - Preferences</title>
     <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background: linear-gradient(135deg, #4e73df 0%, #224abe 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .login-container {
+            width: 100%;
+            max-width: 400px;
+            padding: 20px;
+        }
+
+        .login-card {
+            background-color: #ffffff;
+            padding: 40px;
+            border-radius: 16px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+        }
+
         h1 {
-            color: green;
+            color: #4e73df;
+            margin: 0 0 30px 0;
+            font-size: 1.75rem;
+            font-weight: 700;
+            text-align: center;
+        }
+
+        form p {
+            margin: 0 0 20px 0;
+        }
+
+        label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 8px;
+            color: #495057;
+            font-size: 0.95rem;
+        }
+
+        input[type="text"],
+        input[type="password"] {
+            width: 100%;
+            padding: 14px 16px;
+            font-size: 1rem;
+            border: 2px solid #ced4da;
+            border-radius: 8px;
+            transition: border-color 0.2s, box-shadow 0.2s;
+            font-family: inherit;
+        }
+
+        input[type="text"]:focus,
+        input[type="password"]:focus {
+            outline: none;
+            border-color: #4e73df;
+            box-shadow: 0 0 0 3px rgba(78, 115, 223, 0.15);
+        }
+
+        input[type="submit"] {
+            width: 100%;
+            padding: 16px 24px;
+            font-size: 1.1rem;
+            font-weight: 600;
+            background: linear-gradient(135deg, #4e73df 0%, #224abe 100%);
+            color: white;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            box-shadow: 0 4px 12px rgba(78, 115, 223, 0.3);
+            margin-top: 10px;
+        }
+
+        input[type="submit"]:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 16px rgba(78, 115, 223, 0.4);
+        }
+
+        input[type="submit"]:active {
+            transform: translateY(0);
+        }
+
+        .error-message {
+            background-color: #f8d7da;
+            color: #721c24;
+            border: 2px solid #f5c6cb;
+            padding: 12px 16px;
+            border-radius: 6px;
+            margin: 10px 0;
+            font-size: 0.9rem;
+        }
+
+        @media (max-width: 480px) {
+            .login-card {
+                padding: 30px 20px;
+            }
+
+            h1 {
+                font-size: 1.5rem;
+            }
         }
     </style>
 </head>
 
 <body>
-    <h1>Login to your account</h1>
-    <form action="" method="post" autocomplete="off">
-        {{ form.hidden_tag() }}
-        <p>
-            {{ form.username.label }}<br>
-            {{ form.username(size=32, autocomplete="off") }}<br>
-            {% for error in form.username.errors %}
-            <span style="color: red;">[{{ error }}]</span>
-            {% endfor %}
-        </p>
-        <p>
-            {{ form.password.label }}<br>
-            {{ form.password(size=32, autocomplete="off") }}<br>
-            {% for error in form.password.errors %}
-            <span style="color: red;">[{{ error }}]</span>
-            {% endfor %}
-        </p>
-        <p>{{ form.submit() }}</p>
-        <p>
-            {% for error in form.errors %}
-            <span style="color: red;">[{{ error }}]</span>
-            {% endfor %}
-        </p>
-    </form>
+    <div class="login-container">
+        <div class="login-card">
+            <h1>Login</h1>
+            <form action="" method="post" autocomplete="off">
+                {{ form.hidden_tag() }}
+                <p>
+                    {{ form.username.label }}
+                    {{ form.username(size=32, autocomplete="off") }}
+                    {% for error in form.username.errors %}
+                    <div class="error-message">{{ error }}</div>
+                    {% endfor %}
+                </p>
+                <p>
+                    {{ form.password.label }}
+                    {{ form.password(size=32, autocomplete="off") }}
+                    {% for error in form.password.errors %}
+                    <div class="error-message">{{ error }}</div>
+                    {% endfor %}
+                </p>
+                <p>{{ form.submit() }}</p>
+                {% for error in form.errors %}
+                <div class="error-message">{{ error }}</div>
+                {% endfor %}
+            </form>
+        </div>
+    </div>
 </body>
 
 </html>

--- a/pkgs/python-packages/flasks/rankserver/module.nix
+++ b/pkgs/python-packages/flasks/rankserver/module.nix
@@ -31,6 +31,16 @@ in
   config = lib.mkIf cfg.enable {
     systemd.tmpfiles.rules = [ "d ${cfg.rootDir}/defaultRankables 0755 andrew dev -" ];
 
+    machines.base.webServices = [
+      {
+        name = "Preferences";
+        path = "/rank/";
+        description = "Define preference ordering";
+        icon = "ranking-star";
+        faviconSvg = anixpkgs.pkgData.icons.favicons.ranking-star.data;
+      }
+    ];
+
     systemd.services.rankserver-setup = {
       description = "Reset rankables symlink to defaultRankables";
       wantedBy = [ "multi-user.target" ];

--- a/pkgs/python-packages/flasks/rankserver/rankserver.py
+++ b/pkgs/python-packages/flasks/rankserver/rankserver.py
@@ -2,7 +2,6 @@ import os
 import json
 import sys
 import hashlib
-import tempfile
 import argparse
 import flask
 from PIL import Image
@@ -76,7 +75,12 @@ if args.data_dir[0] == '/':
 else:
     RES_DIR = os.path.join(PWD, args.data_dir)
 SHORT_RESDIR = os.path.basename(os.path.realpath(RES_DIR))
-THUMB_CACHE = os.path.join(tempfile.gettempdir(), "rankserver-thumbs")
+# Cache thumbnails inside the rankables directory itself. RES_DIR is the symlink
+# path, so this always resolves into whatever directory is currently linked —
+# each rankable directory keeps its own persistent cache, and re-pointing the
+# symlink moves the cache with it. Hidden + a directory, so load()'s .txt/.png
+# scan of RES_DIR never picks it up.
+THUMB_CACHE = os.path.join(RES_DIR, ".rankthumbs")
 
 app = flask.Flask(__name__, static_url_path=args.subdomain, static_folder=RES_DIR)
 app.secret_key = _secrets["secret_key"].encode()
@@ -319,17 +323,17 @@ def thumb(filename):
     key = hashlib.sha1(
         f"{os.path.realpath(src)}|{st.st_mtime_ns}|{st.st_size}|{w}".encode()
     ).hexdigest()
-    os.makedirs(THUMB_CACHE, exist_ok=True)
     cached = os.path.join(THUMB_CACHE, key + ".png")
     if not os.path.exists(cached):
         try:
+            os.makedirs(THUMB_CACHE, exist_ok=True)
             img = Image.open(src)
             img.thumbnail((w, 100000000), Image.LANCZOS)
             tmp = cached + ".tmp"
             img.save(tmp, format="PNG")
             os.replace(tmp, cached)
         except Exception:
-            # Fall back to the original on any decode/encode failure.
+            # Fall back to the original on any cache/decode/encode failure.
             return flask.send_file(src, mimetype="image/png", max_age=86400)
     return flask.send_file(cached, mimetype="image/png", max_age=86400)
 

--- a/pkgs/python-packages/flasks/rankserver/rankserver.py
+++ b/pkgs/python-packages/flasks/rankserver/rankserver.py
@@ -1,8 +1,11 @@
 import os
 import json
 import sys
+import hashlib
+import tempfile
 import argparse
 import flask
+from PIL import Image
 import flask_login
 import flask_wtf
 from wtforms import StringField, PasswordField, SubmitField
@@ -73,6 +76,7 @@ if args.data_dir[0] == '/':
 else:
     RES_DIR = os.path.join(PWD, args.data_dir)
 SHORT_RESDIR = os.path.basename(os.path.realpath(RES_DIR))
+THUMB_CACHE = os.path.join(tempfile.gettempdir(), "rankserver-thumbs")
 
 app = flask.Flask(__name__, static_url_path=args.subdomain, static_folder=RES_DIR)
 app.secret_key = _secrets["secret_key"].encode()
@@ -293,6 +297,41 @@ def set_rankables_dir():
         return flask.jsonify({'success': True, 'real_path': new_target})
     except Exception as e:
         return flask.jsonify({'success': False, 'error': str(e)}), 500
+
+@bp.route("/thumb/<path:filename>", methods=["GET"])
+@flask_login.login_required
+def thumb(filename):
+    # Downscaled, disk-cached thumbnail. Lets the ranking page show many images
+    # without downloading every full-resolution file. Cache key includes mtime
+    # and size so edits (rotate/crop elsewhere) invalidate stale thumbnails.
+    safe = os.path.basename(filename)
+    if safe != filename or not safe.lower().endswith(".png"):
+        flask.abort(404)
+    src = os.path.join(RES_DIR, safe)
+    if not os.path.isfile(src):
+        flask.abort(404)
+    try:
+        w = int(flask.request.args.get("w", 240))
+    except (TypeError, ValueError):
+        w = 240
+    w = max(16, min(w, 2000))
+    st = os.stat(src)
+    key = hashlib.sha1(
+        f"{os.path.realpath(src)}|{st.st_mtime_ns}|{st.st_size}|{w}".encode()
+    ).hexdigest()
+    os.makedirs(THUMB_CACHE, exist_ok=True)
+    cached = os.path.join(THUMB_CACHE, key + ".png")
+    if not os.path.exists(cached):
+        try:
+            img = Image.open(src)
+            img.thumbnail((w, 100000000), Image.LANCZOS)
+            tmp = cached + ".tmp"
+            img.save(tmp, format="PNG")
+            os.replace(tmp, cached)
+        except Exception:
+            # Fall back to the original on any decode/encode failure.
+            return flask.send_file(src, mimetype="image/png", max_age=86400)
+    return flask.send_file(cached, mimetype="image/png", max_age=86400)
 
 @app.before_request
 def refresh_session():

--- a/pkgs/python-packages/flasks/rankserver/rankserver.py
+++ b/pkgs/python-packages/flasks/rankserver/rankserver.py
@@ -72,6 +72,7 @@ if args.data_dir[0] == '/':
     RES_DIR = args.data_dir
 else:
     RES_DIR = os.path.join(PWD, args.data_dir)
+SHORT_RESDIR = os.path.basename(os.path.realpath(RES_DIR))
 
 app = flask.Flask(__name__, static_url_path=args.subdomain, static_folder=RES_DIR)
 app.secret_key = _secrets["secret_key"].encode()
@@ -202,7 +203,7 @@ def login():
         flask_login.login_user(user, remember=False)
         flask.session.permanent = True
         next = flask.request.args.get('next')
-        return flask.redirect(next or flask.url_for(url_for_prefix + 'index'))
+        return flask.redirect(next or flask.url_for(url_for_prefix + 'intro'))
     return flask.render_template("login.html", title="Sign In", form=form)
       
 @bp.route("/logout")
@@ -230,13 +231,68 @@ def index():
     
     res, msg = rankserver.load()
     if not res:
-        return flask.render_template("index.html", urlroot=urlroot, err=True, done=False, msg=msg, rlist=[], l="", n="")
+        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=True, done=False, msg=msg, rlist=[], l="", r="")
     rlist = rankserver.getRankList()
     if rankserver.sortingComplete():
-        return flask.render_template("index.html", urlroot=urlroot, err=False, done=True, msg="", rlist=rlist, l="", n="")
+        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=False, done=True, msg="", rlist=rlist, l="", r="")
     else:
         l, r = rankserver.getCompFiles()
-        return flask.render_template("index.html", urlroot=urlroot, err=False, done=False, msg="", rlist=rlist, l=l, r=r)
+        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=False, done=False, msg="", rlist=rlist, l=l, r=r)
+
+@bp.route("/intro", methods=["GET"])
+@flask_login.login_required
+def intro():
+    global urlroot
+    global SHORT_RESDIR
+    return flask.render_template("index.html", urlroot=urlroot, intro=True, datadir=SHORT_RESDIR, err=False, done=False, msg="", rlist=[], l="", r="")
+
+@bp.route("/api/rankables-info", methods=["GET"])
+@flask_login.login_required
+def rankables_info():
+    is_link = os.path.islink(RES_DIR)
+    realpath = os.path.realpath(RES_DIR)
+    return flask.jsonify({
+        'is_symlink': is_link,
+        'symlink_path': RES_DIR,
+        'real_path': realpath
+    })
+
+@bp.route("/api/list-dirs", methods=["POST"])
+@flask_login.login_required
+def list_dirs():
+    data = flask.request.get_json()
+    path = os.path.normpath(data.get('path', '/'))
+    try:
+        entries = os.listdir(path)
+        dirs = sorted([e for e in entries if os.path.isdir(os.path.join(path, e)) and not e.startswith('.')])
+        hidden_dirs = sorted([e for e in entries if os.path.isdir(os.path.join(path, e)) and e.startswith('.')])
+        parent = os.path.dirname(path) if path != '/' else None
+        return flask.jsonify({'path': path, 'parent': parent, 'dirs': dirs + hidden_dirs})
+    except PermissionError:
+        return flask.jsonify({'error': 'Permission denied'}), 403
+    except FileNotFoundError:
+        return flask.jsonify({'error': 'Path not found'}), 404
+
+@bp.route("/api/set-rankables-dir", methods=["POST"])
+@flask_login.login_required
+def set_rankables_dir():
+    global SHORT_RESDIR
+    data = flask.request.get_json()
+    new_target = data.get('path')
+    if not new_target:
+        return flask.jsonify({'success': False, 'error': 'Missing path parameter'}), 400
+    new_target = os.path.normpath(new_target)
+    if not os.path.isdir(new_target):
+        return flask.jsonify({'success': False, 'error': 'Path is not a directory'}), 400
+    if not os.path.islink(RES_DIR):
+        return flask.jsonify({'success': False, 'error': 'Rankables path is not a symlink; cannot reroute'}), 400
+    try:
+        os.unlink(RES_DIR)
+        os.symlink(new_target, RES_DIR)
+        SHORT_RESDIR = os.path.basename(os.path.realpath(RES_DIR))
+        return flask.jsonify({'success': True, 'real_path': new_target})
+    except Exception as e:
+        return flask.jsonify({'success': False, 'error': str(e)}), 500
 
 @app.before_request
 def refresh_session():


### PR DESCRIPTION
## Summary

Brings the **rankserver** Flask UI up to parity with stampserver: modern card-based styling, a real login page, a post-login intro/landing page with a filesystem directory picker, and registration on the root services landing page.

### Changes
- **Styling overhaul** — `login.html` and `index.html` rebuilt with stampserver's palette (`#4e73df`/`#224abe`), white cards, nav bar, and mobile-friendly layout.
- **Intro page** — after login the user lands on a "Rankables Directory" page that shows where the `rankables` symlink currently points and lets them re-point it via a filesystem dir-picker, then a **Start Ranking** button. New routes/endpoints: `/intro`, `/api/rankables-info`, `/api/list-dirs`, `/api/set-rankables-dir` (mirrors stampserver's stampables reroute).
- **Ranking UI** — pairwise comparison shown as two side-by-side cards with green "Choose" buttons, a numbered "Current Ranking" list, and a styled "Sorting complete / Refine Rankings" banner.
- **Root-URL registration** — `module.nix` registers the UI on the landing page as **Preferences** / *Define preference ordering* with a new `ranking-star` icon.
- **Icon** — the `ranking-star` FA6 icon was added to [`anixdata`](https://github.com/goromal/anixdata) (both `fa6-solid` and `favicons` collections); `flake.lock` is bumped to pick it up.

### Bug fix (included)
- **Compare image overlapping the ranked list** — the comparison `<img>` was a direct flex item of `.compare-media`. A replaced element with `height:auto` inside a flex container can fail to reserve its aspect-ratio height in WebKit, collapsing the container so the image overflowed and overlapped the ranked list. Switched to plain block flow (`display:block` image), mirroring stampserver's `.image-container`.

## Testing
- `rankserver` Nix package builds clean; Python compiles; Nix files parse.
- Exercised end-to-end over HTTP against the built binary: login → intro → dir-picker APIs → symlink reroute → comparison (`choose_l`/`choose_r`) → done banner. No server errors.
- Deployed to the local machine via `anix-upgrade --local`; root landing page shows the Preferences entry + icon, favicons serve, and the service is active.
- ⚠️ No browser engine available in the dev environment, so the image-overlap fix was verified by matching stampserver's proven block-layout pattern and confirming clean render, not by pixel/screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)