### PR TITLE
ci: gate auto-commits to PRs and add closure-diff checkbox bot

### DIFF
--- a/.github/workflows/closure-diff-setup.yml
+++ b/.github/workflows/closure-diff-setup.yml
@@ -1,0 +1,39 @@
+name: "Closure Diff Bot Setup"
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  comment-pr:
+    name: Generate Closure Diff Comment
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check for Existing Comment
+        id: check_comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if there's already a closure-diff bot comment on this PR
+          EXISTING_COMMENT=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+          --jq '.[] | select(.body | startswith("## NixOS Closure Diff"))')
+          if [[ -z "$EXISTING_COMMENT" ]]; then
+            echo "no_comment=true" >> $GITHUB_ENV
+          else
+            echo "no_comment=false" >> $GITHUB_ENV
+          fi
+      - name: Post Closure Diff Form
+        if: env.no_comment == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -s \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "body": "## NixOS Closure Diff\n\nCheck the box to compute the NixOS profile closure diff for this PR against its merge-base with master.\n\n- [ ] Run NixOS closure diff"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"

--- a/.github/workflows/closure-diff-trigger.yml
+++ b/.github/workflows/closure-diff-trigger.yml
@@ -1,0 +1,44 @@
+name: "Closure Diff Bot Trigger"
+
+on:
+  issue_comment:
+    types:
+      - edited
+
+jobs:
+  dispatch-diff:
+    name: Trigger NixOS Closure Diff
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+      - name: Check if closure diff box is checked
+        id: check
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if echo "$COMMENT_BODY" | grep -qiE '^- \[x\] Run NixOS closure diff'; then
+            echo "checked=true" >> $GITHUB_OUTPUT
+          else
+            echo "checked=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Resolve PR branch
+        if: steps.check.outputs.checked == 'true'
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          PR_BRANCH=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json headRefName --jq '.headRefName')
+          echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+      - name: Dispatch closure diff workflow
+        if: steps.check.outputs.checked == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run nixos-profile-diff.yml \
+            --repo ${{ github.repository }} \
+            --ref ${{ steps.pr.outputs.branch }} \
+            -f pr_number=${{ github.event.issue.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,14 @@ jobs:
         nix-shell -p nixfmt --run "bash scripts/lint.sh"
         num_changes=$(git status --porcelain=v1 2>/dev/null | wc -l)
         if [[ $num_changes -ge 1 ]]; then
-          echo "Committing linting changes"
-          git add .
-          git commit -m "Lint format"
-          git push origin $branch
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Committing linting changes"
+            git add .
+            git commit -m "Lint format"
+            git push origin $branch
+          else
+            echo "Lint changes detected, but skipping auto-commit on ${{ github.event_name }}"
+          fi
         else
           echo "No linting changes to commit"
         fi
@@ -56,10 +60,14 @@ jobs:
         python scripts/update_deps.py
         num_changes=$(git status --porcelain=v1 2>/dev/null | wc -l)
         if [[ $num_changes -ge 1 ]]; then
-          echo "Committing changes to flake lock"
-          git add .
-          git commit -m "Update flake lock"
-          git push origin $branch
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Committing changes to flake lock"
+            git add .
+            git commit -m "Update flake lock"
+            git push origin $branch
+          else
+            echo "Flake lock out of date, but skipping auto-commit on ${{ github.event_name }}"
+          fi
         else
           echo "No lock changes to commit"
         fi


### PR DESCRIPTION
## Summary

- Gate the **lint-format** and **flake.lock** auto-commit/push steps in `test.yml` so they only run on `pull_request` events. On pushes to master the fix is still applied on-disk (so the `lint.sh check` / `nix flake lock --no-update-lock-file` verification still runs), but nothing is committed to master.
- Add a **closure-diff checkbox bot**, mirroring the existing changelog bot:
  - `closure-diff-setup.yml` — on PR open, posts a comment with a `- [ ] Run NixOS closure diff` checkbox (deduped on its own `## NixOS Closure Diff` marker).
  - `closure-diff-trigger.yml` — on `issue_comment: edited`, detects the checked box and dispatches the existing `nixos-profile-diff.yml` against the PR branch with `pr_number`, which computes and posts the closure diff.

## Notes

- The trigger reuses the existing `nixos-profile-diff.yml` rather than duplicating its logic.
- Requires `GITHUB_TOKEN` workflow permissions to allow `actions: write` (to dispatch) and `pull-requests: read`.
- `gh workflow run --ref <PR branch>` requires `nixos-profile-diff.yml` to exist on the PR branch.
- Like the changelog bot, it re-fires whenever a comment with the box still checked is edited; it does not auto-uncheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)