### PR TITLE
[web] Reset-to-default symlink buttons + "Restart ComfyUI" button

### DIFF
--- a/pkgs/nixos/modules/comfyui/module.nix
+++ b/pkgs/nixos/modules/comfyui/module.nix
@@ -214,6 +214,19 @@ in
         systemd.tmpfiles.rules = [
           "d ${cfg.cozy.stateDir} 0755 andrew dev -"
         ];
+        # Let the cozy UI (running as andrew) restart ComfyUI via its
+        # "Restart ComfyUI" button. Narrowly scoped: only andrew, only
+        # comfyui.service, no password prompt.
+        security.polkit.enable = true;
+        security.polkit.extraConfig = ''
+          polkit.addRule(function(action, subject) {
+            if (action.id == "org.freedesktop.systemd1.manage-units" &&
+                action.lookup("unit") == "comfyui.service" &&
+                subject.user == "andrew") {
+              return polkit.Result.YES;
+            }
+          });
+        '';
         systemd.services.cozy = {
           enable = true;
           description = "cozy ComfyUI image-generation UI";
@@ -221,7 +234,7 @@ in
           unitConfig.StartLimitIntervalSec = 0;
           serviceConfig = {
             Type = "simple";
-            ExecStart = "${cfg.cozy.package}/bin/cozy --port ${builtins.toString service-ports.cozy} --subdomain /cozy --comfyui-url http://127.0.0.1:${builtins.toString cfg.port} --state-dir ${cfg.cozy.stateDir} --workflow-dir ${cfg.cozy.workflowDir} --input-dir ${cfg.cozy.inputDir} --output-dir ${cfg.cozy.outputDir} --workflows ${lib.concatStringsSep "," cfg.cozy.workflows} --secrets-file ${cfg.cozy.secretsFile}";
+            ExecStart = "${cfg.cozy.package}/bin/cozy --port ${builtins.toString service-ports.cozy} --subdomain /cozy --comfyui-url http://127.0.0.1:${builtins.toString cfg.port} --state-dir ${cfg.cozy.stateDir} --workflow-dir ${cfg.cozy.workflowDir} --input-dir ${cfg.cozy.inputDir} --output-dir ${cfg.cozy.outputDir} --workflows ${lib.concatStringsSep "," cfg.cozy.workflows} --secrets-file ${cfg.cozy.secretsFile} --comfyui-restart-cmd '${pkgs.systemd}/bin/systemctl restart comfyui.service'";
             ReadWritePaths = [ cfg.cozy.stateDir ];
             WorkingDirectory = cfg.cozy.stateDir;
             Restart = "always";

--- a/pkgs/python-packages/flasks/cozy/cozy.py
+++ b/pkgs/python-packages/flasks/cozy/cozy.py
@@ -1,6 +1,8 @@
 import argparse
 import json
 import os
+import shlex
+import subprocess
 import sys
 
 import flask
@@ -102,7 +104,7 @@ class User(flask_login.UserMixin):
 
 def create_app(store, workflows, workflow_dir, subdomain="/cozy",
                input_dir=None, output_dir=None, workflow_kinds=None,
-               secret_key=None, password_hash=None):
+               secret_key=None, password_hash=None, restart_cmd=None):
     global _PW_HASH
     if password_hash is not None:
         _PW_HASH = password_hash
@@ -154,7 +156,7 @@ def create_app(store, workflows, workflow_dir, subdomain="/cozy",
         state["job"]["duration"] = job_duration(state["job"])
         return flask.render_template(
             "index.html", urlroot=urlroot, workflows=workflows, state=state,
-            workflow_kinds=workflow_kinds)
+            workflow_kinds=workflow_kinds, can_restart=bool(restart_cmd))
 
     @bp.route("/api/generate", methods=["POST"])
     @flask_login.login_required
@@ -219,6 +221,20 @@ def create_app(store, workflows, workflow_dir, subdomain="/cozy",
         store.clear()
         return flask.jsonify({"ok": True})
 
+    @bp.route("/api/restart-comfyui", methods=["POST"])
+    @flask_login.login_required
+    def restart_comfyui():
+        if not restart_cmd:
+            return flask.jsonify({"error": "restart not configured"}), 503
+        try:
+            subprocess.run(restart_cmd, check=True, timeout=30,
+                           capture_output=True, text=True)
+        except subprocess.CalledProcessError as e:
+            return flask.jsonify({"error": (e.stderr or "").strip() or "restart failed"}), 500
+        except Exception as e:
+            return flask.jsonify({"error": str(e)}), 500
+        return flask.jsonify({"ok": True})
+
     app.register_blueprint(bp)
     login_manager.init_app(app)
     login_manager.login_view = prefix + "login"
@@ -250,6 +266,9 @@ def run():
                              "(default <workflow-dir>/output)")
     parser.add_argument("--secrets-file", type=str, required=True,
                         help="Path to JSON file with secret_key and password_hash")
+    parser.add_argument("--comfyui-restart-cmd", type=str, default="",
+                        help="Command run to restart ComfyUI (e.g. "
+                             "'systemctl restart comfyui.service'); empty hides the restart button")
     args = parser.parse_args()
 
     state_dir = args.state_dir or os.path.join(os.getcwd(), "cozy-state")
@@ -264,12 +283,14 @@ def run():
     }
     store = JobStore(state_dir, ComfyUIClient(args.comfyui_url))
     secrets = _load_secrets(args.secrets_file)
+    restart_cmd = shlex.split(args.comfyui_restart_cmd) if args.comfyui_restart_cmd else None
     app = create_app(store=store, workflows=names,
                      workflow_dir=workflow_dir, subdomain=args.subdomain,
                      input_dir=input_dir, output_dir=output_dir,
                      workflow_kinds=workflow_kinds,
                      secret_key=secrets["secret_key"].encode(),
-                     password_hash=secrets["password_hash"])
+                     password_hash=secrets["password_hash"],
+                     restart_cmd=restart_cmd)
     app.run(host="0.0.0.0", port=args.port)
 
 

--- a/pkgs/python-packages/flasks/cozy/templates/index.html
+++ b/pkgs/python-packages/flasks/cozy/templates/index.html
@@ -33,6 +33,9 @@
         }
         button:disabled { opacity:0.5; cursor:not-allowed; }
         button.clear { background:#6c757d; box-shadow:none; }
+        button.restart { background:#e74a3b; box-shadow:none; }
+        .restart-row { margin-top:32px; padding-top:20px; border-top:1px solid #e9ecef; }
+        .restart-row button { margin-top:0; }
         .prompt-actions { display:flex; gap:8px; margin-top:6px; }
         button.secondary {
             margin-top:0; width:auto; padding:6px 14px; font-size:0.85rem; font-weight:600;
@@ -98,6 +101,12 @@
 
         <div id="output"></div>
         <button class="clear" id="clear">Clear</button>
+
+        {% if can_restart %}
+        <div class="restart-row">
+            <button class="restart" id="restart">Restart ComfyUI</button>
+        </div>
+        {% endif %}
     </div>
 
     <script>
@@ -241,6 +250,27 @@
             imageSelect.value = ""; updatePreview();
             output.innerHTML = ""; showError(""); showDuration(null); bar.style.width = "0%";
         });
+
+        const restartBtn = document.getElementById("restart");
+        if (restartBtn) {
+            restartBtn.addEventListener("click", async () => {
+                if (!confirm("Restart the ComfyUI service? Any in-progress generation will be interrupted.")) return;
+                showError("");
+                const orig = restartBtn.textContent;
+                restartBtn.disabled = true;
+                restartBtn.textContent = "Restarting…";
+                try {
+                    const r = await fetch(root + "api/restart-comfyui", { method: "POST" });
+                    const d = await r.json().catch(() => ({}));
+                    if (!r.ok) showError(d.error || "restart failed");
+                    else { restartBtn.textContent = "✓ Restarted"; }
+                } catch (e) {
+                    showError("restart failed: " + e.message);
+                } finally {
+                    setTimeout(() => { restartBtn.textContent = orig; restartBtn.disabled = false; }, 1500);
+                }
+            });
+        }
 
         // --- Copy / Paste prompt helpers ---
         const copyBtn = document.getElementById("copy-btn");

--- a/pkgs/python-packages/flasks/cozy/tests/test_app.py
+++ b/pkgs/python-packages/flasks/cozy/tests/test_app.py
@@ -14,6 +14,7 @@ class FakeStore:
 
     def read_state(self):
         return {"workflow": "imggen", "prompt": "p", "width": 400, "height": 800,
+                "image": "",
                 "job": {"status": "running" if self._running else "idle",
                         "progress": 42, "error": None,
                         "started_at": "2026-06-23T10:00:00-06:00",
@@ -169,3 +170,45 @@ def test_edit_generate_rejects_output_traversal(edit_client):
         "/cozy/api/generate",
         json={"workflow": "imgedit", "prompt": "hi", "image": "../secret.txt [output]"})
     assert bad.status_code == 400
+
+
+def _restart_client(tmp_path, monkeypatch, restart_cmd):
+    monkeypatch.setattr(cozy, "_check_password", lambda pw: True)
+    app = cozy.create_app(store=FakeStore(), workflows=["imggen"],
+                          workflow_dir=str(tmp_path), subdomain="/cozy",
+                          restart_cmd=restart_cmd)
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    return app.test_client()
+
+
+def test_restart_disabled_when_unconfigured(tmp_path, monkeypatch):
+    c = _restart_client(tmp_path, monkeypatch, None)
+    _login(c)
+    r = c.post("/cozy/api/restart-comfyui")
+    assert r.status_code == 503
+    # The button is hidden from the page when no restart command is configured.
+    assert b'id="restart"' not in c.get("/cozy/").data
+
+
+def test_restart_runs_configured_command(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(cozy.subprocess, "run",
+                        lambda cmd, **kw: calls.append(cmd) or None)
+    c = _restart_client(tmp_path, monkeypatch, ["systemctl", "restart", "comfyui.service"])
+    _login(c)
+    r = c.post("/cozy/api/restart-comfyui")
+    assert r.status_code == 200 and r.get_json()["ok"] is True
+    assert calls == [["systemctl", "restart", "comfyui.service"]]
+    assert b'id="restart"' in c.get("/cozy/").data
+
+
+def test_restart_reports_command_failure(tmp_path, monkeypatch):
+    def boom(cmd, **kw):
+        raise cozy.subprocess.CalledProcessError(1, cmd, stderr="unit not found")
+    monkeypatch.setattr(cozy.subprocess, "run", boom)
+    c = _restart_client(tmp_path, monkeypatch, ["systemctl", "restart", "comfyui.service"])
+    _login(c)
+    r = c.post("/cozy/api/restart-comfyui")
+    assert r.status_code == 500
+    assert r.get_json()["error"] == "unit not found"

--- a/pkgs/python-packages/flasks/rankserver/index.html
+++ b/pkgs/python-packages/flasks/rankserver/index.html
@@ -460,6 +460,7 @@
                 <span class="realpath-label">Current real path:</span>
                 <span class="realpath-value" id="rankablesRealPath">Loading...</span>
                 <button class="btn btn-sm" onclick="openDirPicker()">Change&hellip;</button>
+                <button class="btn btn-sm" onclick="resetRankablesDir()">Reset to default</button>
             </div>
             <div class="dir-picker" id="dirPicker" style="display: none;">
                 <div class="dir-picker-header">
@@ -550,6 +551,7 @@
 
         {% if intro %}
         let _pickerPath = '/';
+        let _defaultPath = null;
 
         function loadRankablesInfo() {
             fetch('{{ urlroot }}api/rankables-info')
@@ -557,6 +559,7 @@
                 .then(data => {
                     document.getElementById('rankablesRealPath').textContent = data.real_path;
                     _pickerPath = data.real_path;
+                    _defaultPath = data.default_path;
                 })
                 .catch(() => {
                     document.getElementById('rankablesRealPath').textContent = '(error loading)';
@@ -622,6 +625,27 @@
                     closeDirPicker();
                     document.getElementById('rankablesRealPath').textContent = data.real_path;
                     showStatus('Rankables directory updated to: ' + data.real_path);
+                } else {
+                    showStatus('Error: ' + (data.error || 'Unknown error'), true);
+                }
+            })
+            .catch(err => showStatus('Error: ' + err.message, true));
+        }
+
+        function resetRankablesDir() {
+            if (!_defaultPath) { showStatus('Default directory unknown', true); return; }
+            if (!confirm('Reset rankables directory to default:\n' + _defaultPath)) return;
+            fetch('{{ urlroot }}api/set-rankables-dir', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({path: _defaultPath})
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    closeDirPicker();
+                    document.getElementById('rankablesRealPath').textContent = data.real_path;
+                    showStatus('Rankables directory reset to default: ' + data.real_path);
                 } else {
                     showStatus('Error: ' + (data.error || 'Unknown error'), true);
                 }

--- a/pkgs/python-packages/flasks/rankserver/rankserver.py
+++ b/pkgs/python-packages/flasks/rankserver/rankserver.py
@@ -75,6 +75,8 @@ if args.data_dir[0] == '/':
 else:
     RES_DIR = os.path.join(PWD, args.data_dir)
 SHORT_RESDIR = os.path.basename(os.path.realpath(RES_DIR))
+# Remember where the symlink pointed at startup so the UI can reset back to it.
+DEFAULT_TARGET = os.path.realpath(RES_DIR)
 # Cache thumbnails inside the rankables directory itself. RES_DIR is the symlink
 # path, so this always resolves into whatever directory is currently linked —
 # each rankable directory keeps its own persistent cache, and re-pointing the
@@ -262,7 +264,8 @@ def rankables_info():
     return flask.jsonify({
         'is_symlink': is_link,
         'symlink_path': RES_DIR,
-        'real_path': realpath
+        'real_path': realpath,
+        'default_path': DEFAULT_TARGET
     })
 
 @bp.route("/api/list-dirs", methods=["POST"])

--- a/pkgs/python-packages/flasks/stampserver/index.html
+++ b/pkgs/python-packages/flasks/stampserver/index.html
@@ -784,6 +784,7 @@
                 <span class="realpath-label">Current real path:</span>
                 <span class="realpath-value" id="stampablesRealPath">Loading...</span>
                 <button class="btn btn-sm" onclick="openDirPicker()">Change&hellip;</button>
+                <button class="btn btn-sm" onclick="resetStampablesDir()">Reset to default</button>
             </div>
             <div class="dir-picker" id="dirPicker" style="display: none;">
                 <div class="dir-picker-header">
@@ -1292,6 +1293,7 @@
 
         {% if root == "zzz" %}
         let _pickerPath = '/';
+        let _defaultPath = null;
 
         function loadStampablesInfo() {
             fetch('{{ urlroot }}api/stampables-info')
@@ -1299,6 +1301,7 @@
                 .then(data => {
                     document.getElementById('stampablesRealPath').textContent = data.real_path;
                     _pickerPath = data.real_path;
+                    _defaultPath = data.default_path;
                 })
                 .catch(() => {
                     document.getElementById('stampablesRealPath').textContent = '(error loading)';
@@ -1364,6 +1367,27 @@
                     closeDirPicker();
                     document.getElementById('stampablesRealPath').textContent = data.real_path;
                     showStatus('Stampables directory updated to: ' + data.real_path);
+                } else {
+                    showStatus('Error: ' + (data.error || 'Unknown error'), true);
+                }
+            })
+            .catch(err => showStatus('Error: ' + err.message, true));
+        }
+
+        function resetStampablesDir() {
+            if (!_defaultPath) { showStatus('Default directory unknown', true); return; }
+            if (!confirm('Reset stampables directory to default:\n' + _defaultPath)) return;
+            fetch('{{ urlroot }}api/set-stampables-dir', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({path: _defaultPath})
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    closeDirPicker();
+                    document.getElementById('stampablesRealPath').textContent = data.real_path;
+                    showStatus('Stampables directory reset to default: ' + data.real_path);
                 } else {
                     showStatus('Error: ' + (data.error || 'Unknown error'), true);
                 }

--- a/pkgs/python-packages/flasks/stampserver/stampserver.py
+++ b/pkgs/python-packages/flasks/stampserver/stampserver.py
@@ -69,6 +69,8 @@ if args.data_dir[0] == '/':
 else:
     RES_DIR = os.path.join(PWD, args.data_dir)
 SHORT_RESDIR = os.path.basename(os.path.realpath(RES_DIR))
+# Remember where the symlink pointed at startup so the UI can reset back to it.
+DEFAULT_TARGET = os.path.realpath(RES_DIR)
 
 app = flask.Flask(__name__, static_url_path=args.subdomain, static_folder=RES_DIR)
 app.secret_key = _secrets["secret_key"].encode()
@@ -291,7 +293,8 @@ def stampables_info():
     return flask.jsonify({
         'is_symlink': is_link,
         'symlink_path': RES_DIR,
-        'real_path': realpath
+        'real_path': realpath,
+        'default_path': DEFAULT_TARGET
     })
 
 @bp.route("/api/list-dirs", methods=["POST"])


### PR DESCRIPTION
Two self-contained UI additions to the Flask apps.

## 1. "Reset to default" symlink button (stampserver + rankserver)
Both UIs let you re-point the stampables/rankables data-dir symlink via a directory picker, but there was no way to get back to where it started. Now:
- Capture the symlink's target at startup as `DEFAULT_TARGET`.
- Expose it as `default_path` on the existing `*-info` endpoint.
- Add a **Reset to default** button that repoints via the existing `set-*-dir` endpoint (which already validates the target is a directory and the path is a symlink) — no new server-side validation needed.

"Default" here means the symlink target at server startup.

## 2. "Restart ComfyUI" button (cozy)
- New `POST /api/restart-comfyui` route runs a configured restart command (new `--comfyui-restart-cmd` arg; empty = button hidden). Returns 503 if unconfigured, 500 with the command's stderr on failure.
- Red **Restart ComfyUI** button at the bottom of the page, gated on `can_restart`, with a confirm dialog and inline status/error feedback.
- The comfyui NixOS module passes `systemctl restart comfyui.service` and grants the cozy service (running as `andrew`) permission via a narrowly-scoped **polkit** rule (only `andrew`, only `comfyui.service`, no password).

## Verification
- Cozy test suite: **13 passed** (added 3 tests — 503 when unconfigured + button hidden, command invoked + button shown, stderr surfaced on failure; made `FakeStore` faithful by adding the `image` key the template reads).
- All four Python scripts byte-compile; the comfyui module parses and evaluates (ExecStart, `polkit.enable`, and the polkit rule render as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)