### PR TITLE
ci: scope changelog-setup dedup to its own comment marker

### DIFF
--- a/.github/workflows/changelog-setup.yml
+++ b/.github/workflows/changelog-setup.yml
@@ -17,9 +17,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Check if there's already a bot comment on this PR
+          # Check if there's already a changelog bot comment on this PR.
+          # Match on this bot's own marker so other bot comments (e.g. the
+          # closure-diff form) don't get mistaken for it.
           EXISTING_COMMENT=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-          --jq '.[] | select(.user.login=="github-actions[bot]")')
+          --jq '.[] | select(.body | startswith("## Change Description"))')
           if [[ -z "$EXISTING_COMMENT" ]]; then
             echo "no_comment=true" >> $GITHUB_ENV
           else


### PR DESCRIPTION
## Summary

Fixes a regression from #567. The changelog setup deduped on *any* `github-actions[bot]` comment. Now that the closure-diff setup posts as the same bot, whichever workflow posted first suppressed the other — on #568 only the closure-diff comment appeared and the changelog form was skipped.

This keys the changelog dedup check off its own `## Change Description` marker (mirroring how `closure-diff-setup.yml` matches `## NixOS Closure Diff`), so the two forms no longer collide.

## Verification

This PR itself should surface both bot comments (changelog form + closure-diff form) once CI runs — that's the direct test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)