### PR TITLE
[devshell] Add 'd' key to drop TUI into workspace devshell

### DIFF
--- a/changes/pr-573.md
+++ b/changes/pr-573.md
@@ -1,0 +1,1 @@
+[devshell] Add 'd' key to drop TUI into workspace devshell

--- a/pkgs/bash-packages/devshell/default.nix
+++ b/pkgs/bash-packages/devshell/default.nix
@@ -137,8 +137,8 @@ in
               --arg devScript ${devScript} \
               --arg parseScript ${parseScript} \
               --argstr devHistFile "$devhist" \
-              --command "$runcmd"
-        fi 
+              --command "unset DEVSHELL_ACTIVE; $runcmd"
+        fi
     fi
   ''
 )

--- a/pkgs/bash-packages/devshell/dev.py
+++ b/pkgs/bash-packages/devshell/dev.py
@@ -10,6 +10,8 @@ class Context:
         self.help_mode = False
         self.dev_dir = ""
         self.hist_file = ""
+        self.devrc = ""
+        self.drop_to_shell = False
         self.wsname = ""
         self.repos = []
         self.scripts = []
@@ -181,7 +183,8 @@ def display_output(stdscr):
             stdscr.addstr(13, 0, "[n]  Nuke")
             stdscr.addstr(14, 0, "[o]  Add source")
             stdscr.addstr(15, 0, "[i]  Add script")
-            stdscr.addstr(16, 0, "[q]  Quit")
+            stdscr.addstr(16, 0, "[d]  Drop into workspace devshell")
+            stdscr.addstr(17, 0, "[q]  Quit")
             for j, script in enumerate(ctx.scripts):
                 stdscr.addstr(3 + j, 42, f"| {script}")
 
@@ -254,6 +257,7 @@ def main(stdscr):
     ctx.dev_dir = sys.argv[2]
     editor = sys.argv[3]
     ctx.hist_file = sys.argv[4]
+    ctx.devrc = sys.argv[5] if len(sys.argv) > 5 else ""
     ctx.load_sources()
 
     curses.curs_set(0)
@@ -275,6 +279,10 @@ def main(stdscr):
             display_output(stdscr)
 
         elif key == ord("q"):
+            break
+
+        elif key == ord("d"):
+            ctx.drop_to_shell = True
             break
 
         elif not ctx.help_mode:
@@ -570,3 +578,19 @@ def script_prompt(stdscr):
 
 if __name__ == "__main__":
     curses.wrapper(main)
+    if ctx.drop_to_shell:
+        # If we're already inside an interactive devshell for this workspace,
+        # exiting the TUI drops us back into it; nothing more to do. Otherwise
+        # (e.g. launched via `devshell WS --run dev` or a bare invocation), we
+        # replace this process with a fresh interactive devshell.
+        if os.environ.get("DEVSHELL_ACTIVE") != ctx.wsname:
+            devshell_cmd = ["devshell", ctx.wsname]
+            if ctx.hist_file:
+                devshell_cmd += ["-s", os.path.expanduser(ctx.hist_file)]
+            if ctx.devrc:
+                devshell_cmd += ["-d", os.path.expanduser(ctx.devrc)]
+            try:
+                os.execvp("devshell", devshell_cmd)
+            except OSError as e:
+                sys.stderr.write(f"Could not launch devshell: {e}\n")
+                sys.exit(1)

--- a/pkgs/bash-packages/devshell/mkDevShell.nix
+++ b/pkgs/bash-packages/devshell/mkDevShell.nix
@@ -39,7 +39,7 @@ let
     fi
   '';
   dev = pkgs.writeShellScriptBin "dev" ''
-    ${pkgs.python3}/bin/python ${devScript} ${wsname} ${devDir}/${wsname} ${editorName} ${devHistFile}
+    ${pkgs.python3}/bin/python ${devScript} ${wsname} ${devDir}/${wsname} ${editorName} ${devHistFile} ${devrcFile}
   '';
   addsrc = pkgs.writeShellScriptBin "addsrc" ''
     if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
@@ -73,6 +73,7 @@ pkgs.mkShell {
   ];
   shellHook = ''
     export PS1='\n\[\033[1;36m\][devshell=${wsname}:\w]\$\[\033[0m\] '
+    case $- in *i*) export DEVSHELL_ACTIVE=${wsname} ;; esac
     alias godev='cd ${devDir}/${wsname}'
     setupcurrentws
     cd ${devDir}/${wsname}


### PR DESCRIPTION
## Summary

Adds a `d` command to the `dev` TUI that exits the TUI and drops the user into the current workspace's `devshell` nix shell.

Handles both ways `dev` can be reached:

- **Already inside an interactive devshell** (`devshell ws` → `dev`): exiting the TUI already returns you to that shell, so `d` just quits — no nested `nix-shell`, no re-run of `setupcurrentws`.
- **Not in a persistent devshell** (`devshell ws --run dev`, or a bare `python dev.py …`): exiting would leave you with no devshell, so `d` `exec`s a fresh `devshell <ws>` in place of the Python process.

## How the cases are distinguished

The devshell `shellHook` now exports `DEVSHELL_ACTIVE=<ws>` **only for interactive shells** (`case $- in *i*)`), so the non-interactive shell behind `--run`/`--command` doesn't set it. dev.py checks `DEVSHELL_ACTIVE == wsname` to decide whether to relaunch.

## Changes

- `mkDevShell.nix`: export the interactive `DEVSHELL_ACTIVE` marker; pass `devrcFile` as a 5th arg to `dev.py` so a relaunch honors a custom `-d DEVRC`.
- `dev.py`: new `[d]` help line and top-level key handler; reads `argv[5]` (backward-compatible); post-TUI logic `exec`s `devshell <ws> [-s hist] [-d devrc]` when not already in the interactive devshell, with a clean error message if `devshell` isn't on `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)