### PR TITLE
[pc] Gate fileservers and anix-upgrade-ui behind profile options

### DIFF
--- a/changes/pr-577.md
+++ b/changes/pr-577.md
@@ -1,0 +1,1 @@
+[pc] Gate fileservers and anix-upgrade-ui behind profile options

--- a/pkgs/nixos/pc-base.nix
+++ b/pkgs/nixos/pc-base.nix
@@ -196,6 +196,10 @@ in
       default = false;
       description = "Whether to turn on file servers";
     };
+    enableUpgradeUI = lib.mkOption {
+      type = lib.types.bool;
+      description = "Whether to serve the anix-upgrade web UI (implies running the reverse-proxy webserver).";
+    };
     cloudDirs = lib.mkOption {
       type = lib.types.listOf lib.types.attrs;
       description = "List of {name,cloudname,dirname} attributes (dirname is relative to home) defining the syncable directories by rcrsync";
@@ -460,7 +464,7 @@ in
       };
 
       services.anix-upgrade-ui = {
-        enable = true;
+        enable = cfg.enableUpgradeUI;
       };
 
       services.sunset = {

--- a/pkgs/nixos/pc-base.nix
+++ b/pkgs/nixos/pc-base.nix
@@ -474,7 +474,7 @@ in
       };
 
       services.stampserver = {
-        enable = true;
+        enable = cfg.isATS || cfg.enableFileServers;
         package = anixpkgs.stampserver;
         rootDir = "${cfg.homeDir}/fileservers";
       };

--- a/pkgs/nixos/profiles/ats.nix
+++ b/pkgs/nixos/profiles/ats.nix
@@ -23,6 +23,7 @@ in
       notesWikiPort = 8080;
       enableMetrics = true;
       enableFileServers = true;
+      enableUpgradeUI = true;
       cloudDirs = [
         {
           name = "configs";

--- a/pkgs/nixos/profiles/jetpack.nix
+++ b/pkgs/nixos/profiles/jetpack.nix
@@ -22,6 +22,7 @@ in
       serveNotesWiki = false;
       enableMetrics = false; # TODO: perhaps enable in the future
       enableFileServers = true;
+      enableUpgradeUI = true;
       cloudDirs = [
         {
           name = "configs";

--- a/pkgs/nixos/profiles/personal.nix
+++ b/pkgs/nixos/profiles/personal.nix
@@ -20,7 +20,7 @@ in
       agentFramework = "claude";
       serveNotesWiki = false;
       enableMetrics = true;
-      enableFileServers = false;
+      enableFileServers = true;
       cloudDirs = [
         {
           name = "configs";

--- a/pkgs/nixos/profiles/personal.nix
+++ b/pkgs/nixos/profiles/personal.nix
@@ -21,6 +21,7 @@ in
       serveNotesWiki = false;
       enableMetrics = true;
       enableFileServers = true;
+      enableUpgradeUI = true;
       cloudDirs = [
         {
           name = "configs";

--- a/pkgs/nixos/profiles/workstation.nix
+++ b/pkgs/nixos/profiles/workstation.nix
@@ -21,6 +21,7 @@ in
       serveNotesWiki = false;
       enableMetrics = false;
       enableFileServers = false;
+      enableUpgradeUI = false;
       cloudDirs = [
         {
           name = "configs";

--- a/scripts/smoke_test_profiles.py
+++ b/scripts/smoke_test_profiles.py
@@ -26,6 +26,7 @@ BOOL_OPTIONS = [
     "enableMetrics",
     "enableFileServers",
     "enableOrchestrator",
+    "enableUpgradeUI",
 ]
 
 # x86 only in CI; pi4/jetson require cross-compilation setup


### PR DESCRIPTION
Web services were being enabled unconditionally on every `pc-base` machine. This gates them properly per profile.

- Fix `stampserver` gating to honor `isATS || enableFileServers` (was always-on), matching `rankserver`.
- Turn file servers on for personal machines (`enableFileServers = true`).
- Add `machines.base.enableUpgradeUI` to gate the anix-upgrade web UI — and the nginx reverse proxy it pulls in via `runWebServer`. Enabled for personal/ats/jetpack, disabled for workstation.

- [x] nginx should not run on workstation -- was pulled in by the always-on `anix-upgrade-ui` service