### PR TITLE
[fileservers] linking capability

### DIFF
--- a/changes/pr-579.md
+++ b/changes/pr-579.md
@@ -1,0 +1,1 @@
+[fileservers] rankserver stamp-watch linking + resilient sort state

--- a/changes/pr-579.md
+++ b/changes/pr-579.md
@@ -1,1 +1,1 @@
-[fileservers] rankserver stamp-watch linking + resilient sort state
+[fileservers] linking capability

--- a/pkgs/python-packages/flasks/rankserver/default.nix
+++ b/pkgs/python-packages/flasks/rankserver/default.nix
@@ -1,6 +1,7 @@
 {
   buildPythonPackage,
   setuptools,
+  pytestCheckHook,
   flask,
   flask-login,
   flask-wtf,
@@ -45,6 +46,7 @@ buildPythonPackage rec {
     pysorting
     pillow
   ];
+  nativeCheckInputs = [ pytestCheckHook ];
   meta = {
     description = "A portable webserver for ranking files via binary manual comparisons, powered by Python's flask library.";
     longDescription = ''

--- a/pkgs/python-packages/flasks/rankserver/default.nix
+++ b/pkgs/python-packages/flasks/rankserver/default.nix
@@ -51,6 +51,8 @@ buildPythonPackage rec {
     description = "A portable webserver for ranking files via binary manual comparisons, powered by Python's flask library.";
     longDescription = ''
       Spins up a flask webserver (on the specified port) whose purpose is to help a user rank files in the chosen `data-dir` directory via manual binary comparisons. The ranking is done via an incremental "RESTful" sorting strategy implemented within the [pysorting](./pysorting.md) library. State is created and maintained within the `data-dir` directory so that the ranking exercise can pick back up where it left off between different spawnings of the server. At this point, only the ranking of `.txt`, `.png`, and `.mp4` files is possible; other file types in `data-dir` will be ignored.
+
+      A rankables directory may optionally "watch" a stampserver directory via `rank_config.json` (configured in the UI): files carrying a chosen stamp tag are mirrored in as symlinks, removals are absorbed with minimal lost comparison work, and newly stamped files are placed into an existing ranking via binary insertion.
     '';
     autoGenUsageCmd = "--help";
   };

--- a/pkgs/python-packages/flasks/rankserver/index.html
+++ b/pkgs/python-packages/flasks/rankserver/index.html
@@ -559,6 +559,9 @@
             </form>
         </div>
         {% else %}
+        {% if insert_note %}
+        <p class="compare-prompt" style="color: #1cc88a; font-weight: 600;">{{ insert_note }}</p>
+        {% endif %}
         <p class="compare-prompt">Which do you prefer?</p>
         <div class="compare-row">
             <div class="compare-card">

--- a/pkgs/python-packages/flasks/rankserver/index.html
+++ b/pkgs/python-packages/flasks/rankserver/index.html
@@ -534,12 +534,33 @@
                 <div class="dir-picker-header">
                     <span class="dir-picker-path" id="pickerCurrentPath"></span>
                     <button class="btn btn-sm" onclick="pickerNavigateUp()">&#8593; Up</button>
+                    <button class="btn btn-sm" onclick="pickerNewFolder()">+ New Folder</button>
                 </div>
                 <ul class="dir-list" id="dirList"></ul>
                 <div class="dir-picker-actions">
                     <button class="btn btn-sm btn-danger" onclick="closeDirPicker()">Cancel</button>
                     <button class="btn btn-sm" onclick="selectPickerDir()">Select This Directory</button>
                 </div>
+            </div>
+        </div>
+
+        <div class="rankables-config">
+            <h2>Stamp Watch</h2>
+            <p class="help">Optionally mirror files carrying a chosen stamp tag from a
+               stampserver directory into this rankables directory. Symlinks are kept
+               in sync automatically; newly stamped files queue up for placement into
+               the existing ranking.</p>
+            <div class="rankables-realpath">
+                <span class="realpath-label">Status:</span>
+                <span class="realpath-value" id="watchStatus">Loading...</span>
+                <button class="btn btn-sm" onclick="openWatchConfig()">Configure&hellip;</button>
+                <button class="btn btn-sm btn-danger" onclick="clearWatchConfig()">Clear</button>
+            </div>
+            <div class="rankables-realpath" id="watchTagRow" style="display: none;">
+                <span class="realpath-label">Tag for <span id="watchChosenDir"></span>:</span>
+                <select id="watchTagSelect"></select>
+                <button class="btn btn-sm" onclick="saveWatchConfig()">Save</button>
+                <button class="btn btn-sm btn-danger" onclick="cancelWatchConfig()">Cancel</button>
             </div>
         </div>
 
@@ -673,6 +694,8 @@
         {% if intro %}
         let _pickerPath = '/';
         let _defaultPath = null;
+        let _pickerMode = 'rankables';   // 'rankables' | 'stampdir'
+        let _watchDir = null;
 
         function loadRankablesInfo() {
             fetch('{{ urlroot }}api/rankables-info')
@@ -688,6 +711,8 @@
         }
 
         function openDirPicker() {
+            _pickerMode = 'rankables';
+            document.getElementById('watchTagRow').style.display = 'none';
             document.getElementById('dirPicker').style.display = 'block';
             loadPickerDirs(_pickerPath);
         }
@@ -734,6 +759,36 @@
         }
 
         function selectPickerDir() {
+            if (_pickerMode === 'stampdir') {
+                _watchDir = _pickerPath;
+                closeDirPicker();
+                document.getElementById('watchChosenDir').textContent = _watchDir;
+                fetch('{{ urlroot }}api/list-stamps', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({path: _watchDir})
+                })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.error) { showStatus('Error: ' + data.error, true); return; }
+                    const sel = document.getElementById('watchTagSelect');
+                    sel.innerHTML = '';
+                    const tags = Object.entries(data.tags);
+                    if (tags.length === 0) {
+                        showStatus('No stamped rankable files found in ' + _watchDir, true);
+                        return;
+                    }
+                    tags.forEach(([tag, count]) => {
+                        const opt = document.createElement('option');
+                        opt.value = tag;
+                        opt.textContent = tag + ' (' + count + ')';
+                        sel.appendChild(opt);
+                    });
+                    document.getElementById('watchTagRow').style.display = 'flex';
+                })
+                .catch(err => showStatus('Error: ' + err.message, true));
+                return;
+            }
             if (!confirm('Set rankables directory to:\n' + _pickerPath)) return;
             fetch('{{ urlroot }}api/set-rankables-dir', {
                 method: 'POST',
@@ -746,6 +801,7 @@
                     closeDirPicker();
                     document.getElementById('rankablesRealPath').textContent = data.real_path;
                     showStatus('Rankables directory updated to: ' + data.real_path);
+                    loadWatchInfo();
                 } else {
                     showStatus('Error: ' + (data.error || 'Unknown error'), true);
                 }
@@ -767,6 +823,7 @@
                     closeDirPicker();
                     document.getElementById('rankablesRealPath').textContent = data.real_path;
                     showStatus('Rankables directory reset to default: ' + data.real_path);
+                    loadWatchInfo();
                 } else {
                     showStatus('Error: ' + (data.error || 'Unknown error'), true);
                 }
@@ -774,7 +831,86 @@
             .catch(err => showStatus('Error: ' + err.message, true));
         }
 
+        function pickerNewFolder() {
+            const name = prompt('New folder name (inside ' + _pickerPath + '):');
+            if (!name) return;
+            fetch('{{ urlroot }}api/make-dir', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({path: _pickerPath, name: name})
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) { loadPickerDirs(_pickerPath); }
+                else { showStatus('Error: ' + (data.error || 'Unknown error'), true); }
+            })
+            .catch(err => showStatus('Error: ' + err.message, true));
+        }
+
+        function loadWatchInfo() {
+            fetch('{{ urlroot }}api/watch-config')
+                .then(r => r.json())
+                .then(data => {
+                    const el = document.getElementById('watchStatus');
+                    if (data.error) { el.textContent = data.error; return; }
+                    if (!data.watch) { el.textContent = 'Not watching'; return; }
+                    let txt = 'Watching ' + data.watch.stamp_dir + ' for tag "'
+                        + data.watch.stamp_tag + '" — ' + data.linked_count + ' linked';
+                    if (data.queue_len > 0) txt += ' (' + data.queue_len + ' queued)';
+                    el.textContent = txt;
+                })
+                .catch(() => {
+                    document.getElementById('watchStatus').textContent = '(error loading)';
+                });
+        }
+
+        function openWatchConfig() {
+            _pickerMode = 'stampdir';
+            document.getElementById('watchTagRow').style.display = 'none';
+            document.getElementById('dirPicker').style.display = 'block';
+            loadPickerDirs(_pickerPath);
+        }
+
+        function cancelWatchConfig() {
+            document.getElementById('watchTagRow').style.display = 'none';
+            _watchDir = null;
+        }
+
+        function saveWatchConfig() {
+            const tag = document.getElementById('watchTagSelect').value;
+            if (!_watchDir || !tag) { showStatus('Choose a directory and tag first', true); return; }
+            fetch('{{ urlroot }}api/set-watch-config', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({stamp_dir: _watchDir, stamp_tag: tag})
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    cancelWatchConfig();
+                    showStatus('Watch configured; ' + data.linked_count + ' file(s) linked'
+                        + (data.warnings && data.warnings.length ? ' — ' + data.warnings.join('; ') : ''));
+                    loadWatchInfo();
+                } else {
+                    showStatus('Error: ' + (data.error || 'Unknown error'), true);
+                }
+            })
+            .catch(err => showStatus('Error: ' + err.message, true));
+        }
+
+        function clearWatchConfig() {
+            if (!confirm('Stop watching? Existing symlinks are kept.')) return;
+            fetch('{{ urlroot }}api/clear-watch-config', {method: 'POST'})
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) { cancelWatchConfig(); showStatus('Watch cleared'); loadWatchInfo(); }
+                else { showStatus('Error: ' + (data.error || 'Unknown error'), true); }
+            })
+            .catch(err => showStatus('Error: ' + err.message, true));
+        }
+
         loadRankablesInfo();
+        loadWatchInfo();
         {% endif %}
     </script>
 </body>

--- a/pkgs/python-packages/flasks/rankserver/index.html
+++ b/pkgs/python-packages/flasks/rankserver/index.html
@@ -515,6 +515,10 @@
 
         <div id="statusMessage" class="status-message"></div>
 
+        {% if warn %}
+        <div class="status-message status-error" style="display: block;">{{ warn }}</div>
+        {% endif %}
+
         {% if intro %}
         <div class="rankables-config">
             <h2>Rankables Directory</h2>

--- a/pkgs/python-packages/flasks/rankserver/rankops.py
+++ b/pkgs/python-packages/flasks/rankserver/rankops.py
@@ -72,3 +72,128 @@ def plan_sync(stamp_files, data_entries, tag):
         if entry["type"] == "symlink" and entry.get("owned") and entry.get("dangling"):
             to_prune.append(name)
     return to_link, to_prune, warnings
+
+
+def _active_range(state):
+    """(low, high) of the active partition, or None if the base sort is done."""
+    if state["sorted"] == 1 or state["top"] == UINT32_MAX:
+        return None
+    t = state["top"]
+    return (state["stack"][t - 1], state["stack"][t])
+
+
+def _restart_partition(state):
+    """Re-derive p/i/j/l/c from the stack top, mirroring the C++ library's
+    resetPartition — including the i = low-1 uint32 wrap when low == 0."""
+    t = state["top"]
+    low, high = state["stack"][t - 1], state["stack"][t]
+    state["p"] = high
+    state["i"] = low - 1 if low > 0 else UINT32_MAX
+    state["j"] = low
+    state["l"] = LEFT_J
+    state["c"] = NOT_COMPARED
+
+
+def remove_index(state, file_map, k):
+    """Excise file_map[k] from the sort. Returns (state, file_map,
+    partition_restarted) as fresh objects; inputs are not mutated.
+    k must be a valid file_map index present in state["arr"]; a violated
+    invariant raises ValueError (callers derive k from a file_map diff).
+
+    All comparison work is preserved except when the removed element sits
+    inside the active partition, in which case only that partition restarts.
+    """
+    state = dict(state, arr=list(state["arr"]), stack=list(state["stack"]))
+    file_map = list(file_map)
+    pos = state["arr"].index(k)
+    active = _active_range(state)
+
+    state["arr"].pop(pos)
+    state["arr"] = [v - 1 if v > k else v for v in state["arr"]]
+    file_map.pop(k)
+    state["n"] -= 1
+    n = state["n"]
+
+    if state["sorted"] == 1:
+        state["stack"] = [0] * n
+        state["top"] = UINT32_MAX
+        return state, file_map, False
+
+    low_a, high_a = active
+    pos_in_active = low_a <= pos <= high_a
+    if not pos_in_active:
+        # Capture cursor progress relative to the active range before any
+        # shifting. m = size of the "<= pivot" region; j_off = scan offset.
+        i = state["i"]
+        m = 0 if (i == UINT32_MAX or i < low_a) else i - low_a + 1
+        j_off = state["j"] - low_a
+
+    # Shift pending ranges past the removed position; drop ranges that
+    # shrink below 2 elements (they need no further comparisons).
+    pairs = []
+    t = 0
+    while t <= state["top"]:
+        low, high = state["stack"][t], state["stack"][t + 1]
+        low2 = low - 1 if low > pos else low
+        # high == pos means the removed element sat at the range's high
+        # boundary: the range still shrinks, so >= (not >) is required.
+        high2 = high - 1 if high >= pos else high
+        if high2 > low2:
+            pairs.append((low2, high2))
+        t += 2
+    flat = [x for pair in pairs for x in pair]
+    state["stack"] = flat + [0] * (n - len(flat))
+    state["top"] = len(flat) - 1 if flat else UINT32_MAX
+
+    if not pairs:
+        # Sort completed; nothing was restarted and no work was lost.
+        state["sorted"] = 1
+        return state, file_map, False
+
+    if pos_in_active:
+        _restart_partition(state)
+        return state, file_map, True
+
+    # The active partition survived untouched (it is still the top pair);
+    # recompute cursors from the captured offsets.
+    new_low, new_high = pairs[-1]
+    state["p"] = new_high
+    state["j"] = new_low + j_off
+    state["i"] = UINT32_MAX if (new_low == 0 and m == 0) else new_low + m - 1
+    return state, file_map, False
+
+
+def validate_state(state, file_map):
+    """Sanity-check a post-surgery state. Returns (ok, msg)."""
+    n = state["n"]
+    if n == 0:
+        return False, "empty state"
+    if len(file_map) != n:
+        return False, "file_map length {} != n {}".format(len(file_map), n)
+    if len(state["arr"]) != n or len(state["stack"]) != n:
+        return False, "arr/stack length mismatch"
+    if sorted(state["arr"]) != list(range(n)):
+        return False, "arr is not a permutation of 0..n-1"
+    if state["sorted"] == 1:
+        if state["top"] != UINT32_MAX:
+            return False, "sorted state with pending stack"
+        return True, ""
+    if state["sorted"] != 0:
+        return False, "invalid sorted field"
+    top = state["top"]
+    if top == UINT32_MAX:
+        return False, "unsorted state with empty stack"
+    if top >= n or top % 2 == 0:
+        return False, "invalid stack top"
+    for t in range(0, top, 2):
+        low, high = state["stack"][t], state["stack"][t + 1]
+        if not (0 <= low < high < n):
+            return False, "invalid pending range ({}, {})".format(low, high)
+    low_a, high_a = state["stack"][top - 1], state["stack"][top]
+    if state["p"] != high_a:
+        return False, "pivot not at active range high"
+    if not (low_a <= state["j"] <= high_a):
+        return False, "j outside active range"
+    if state["l"] not in (0, 1) or state["c"] not in (0, 1, 2, 3):
+        return False, "invalid comparator fields"
+    return True, ""

--- a/pkgs/python-packages/flasks/rankserver/rankops.py
+++ b/pkgs/python-packages/flasks/rankserver/rankops.py
@@ -197,3 +197,81 @@ def validate_state(state, file_map):
     if state["l"] not in (0, 1) or state["c"] not in (0, 1, 2, 3):
         return False, "invalid comparator fields"
     return True, ""
+
+
+def reconcile(state, file_map, present_files, insertions):
+    """Bring the settled sort state in line with the files actually present.
+
+    present_files: set of rankable filenames in the data dir (post-sync).
+    insertions: {"queue": [names], "active": {"file","lo","hi"} or None}.
+    Returns (state, file_map, insertions, result) as fresh objects, where
+    result = {"changed": bool,          # state/file_map modified -> persist
+              "reset_all": bool,        # settled set emptied -> delete state
+              "partitions_restarted": int}
+    """
+    insertions = {
+        "queue": [f for f in insertions.get("queue", []) if f in present_files],
+        "active": (dict(insertions["active"])
+                   if insertions.get("active")
+                   and insertions["active"]["file"] in present_files
+                   else None),
+    }
+    result = {"changed": False, "reset_all": False, "partitions_restarted": 0}
+
+    missing = [f for f in file_map if f not in present_files]
+    for fname in missing:
+        if len(file_map) == 1:
+            result["reset_all"] = True
+            result["changed"] = True
+            return state, [], {"queue": [], "active": None}, result
+        k = file_map.index(fname)
+        pos = state["arr"].index(k)
+        state, file_map, restarted = remove_index(state, file_map, k)
+        result["changed"] = True
+        if restarted:
+            result["partitions_restarted"] += 1
+        if insertions["active"]:
+            a = insertions["active"]
+            if a["lo"] > pos:
+                a["lo"] -= 1
+            if a["hi"] > pos:
+                a["hi"] -= 1
+
+    known = set(file_map) | set(insertions["queue"])
+    if insertions["active"]:
+        known.add(insertions["active"]["file"])
+    insertions["queue"].extend(sorted(f for f in present_files if f not in known))
+    return state, file_map, insertions, result
+
+
+def insertion_mid(bounds):
+    return (bounds["lo"] + bounds["hi"]) // 2
+
+
+def insertion_done(bounds):
+    return bounds["lo"] >= bounds["hi"]
+
+
+def insertion_step(bounds, prefer_new):
+    """One binary-search comparison. prefer_new=True means the new file beat
+    the element at position insertion_mid(bounds), so it belongs above it
+    (arr is ascending; choose-left maps to LEFT_GREATER)."""
+    bounds = dict(bounds)
+    mid = insertion_mid(bounds)
+    if prefer_new:
+        bounds["lo"] = mid + 1
+    else:
+        bounds["hi"] = mid
+    return bounds
+
+
+def insertion_complete(state, file_map, fname, pos):
+    """Splice a fully-placed new file into a sorted state at arr position pos."""
+    state = dict(state, arr=list(state["arr"]))
+    file_map = list(file_map) + [fname]
+    new_idx = state["n"]
+    state["arr"].insert(pos, new_idx)
+    state["n"] = new_idx + 1
+    state["stack"] = [0] * state["n"]
+    state["top"] = UINT32_MAX
+    return state, file_map

--- a/pkgs/python-packages/flasks/rankserver/rankops.py
+++ b/pkgs/python-packages/flasks/rankserver/rankops.py
@@ -1,0 +1,74 @@
+"""Pure logic for rankserver's stamp-watch and sort-state maintenance.
+
+Stdlib-only; every function operates on plain data so it is unit-testable
+without Flask or pysorting.
+
+QuickSortState is represented as a dict with int keys
+  sorted, n, top, p, i, j, l, c   (uint32 semantics; UINT32_MAX sentinel)
+and list keys arr, stack.
+"pos" values index into arr; values *of* arr index into file_map.
+The stack holds flat (low, high) position pairs, valid up to index `top`
+inclusive; the active partition is (stack[top-1], stack[top]).
+"""
+import re
+
+UINT32_MAX = 0xFFFFFFFF
+RANKABLE_EXTS = (".txt", ".png", ".mp4")
+STAMP_RE = re.compile(r"stamped\.(.*?)\.")
+# QuickSortState enum values (mirror sorting/Sorting.h); used by the
+# sort-state surgery functions added alongside the QuickSortState helpers.
+LEFT_J = 1
+NOT_COMPARED = 0
+CONFIG_NAME = "rank_config.json"
+
+
+def is_rankable(name):
+    return name.lower().endswith(RANKABLE_EXTS)
+
+
+def stamp_prefix(tag):
+    return "stamped.{}.".format(tag)
+
+
+def scan_stamps(listing):
+    """Map stamp tag -> count of rankable files carrying it, sorted by count desc."""
+    tags = {}
+    for f in listing:
+        if not is_rankable(f):
+            continue
+        m = STAMP_RE.match(f)
+        if m:
+            tags[m.group(1)] = tags.get(m.group(1), 0) + 1
+    return dict(sorted(tags.items(), key=lambda kv: kv[1], reverse=True))
+
+
+def plan_sync(stamp_files, data_entries, tag):
+    """Decide symlink operations to mirror tag-matching stamp files.
+
+    stamp_files: iterable of filenames present in the watched stamp dir.
+    data_entries: dict name -> entry describing the data-dir contents, where
+        entry is {"type": "file"|"dir"|"symlink"} plus, for symlinks,
+        "owned" (target's parent resolves into the watched stamp dir) and
+        "dangling" (target no longer exists).
+    Returns (to_link, to_prune, warnings): names to symlink into the data
+    dir, owned dangling symlinks to remove, and human-readable warnings.
+    Linking is scoped to the given tag, but pruning covers owned dangling
+    symlinks of ANY tag: ownership is stamp-dir-based by design, so a file
+    restamped to a different tag still gets its dead link cleaned up.
+    Never proposes touching regular files, dirs, or foreign symlinks.
+    """
+    prefix = stamp_prefix(tag)
+    to_link, to_prune, warnings = [], [], []
+    for name in sorted(stamp_files):
+        if not (name.startswith(prefix) and is_rankable(name)):
+            continue
+        entry = data_entries.get(name)
+        if entry is None:
+            to_link.append(name)
+        elif entry["type"] == "file":
+            warnings.append("Regular file blocks stamped name: {}".format(name))
+    for name in sorted(data_entries):
+        entry = data_entries[name]
+        if entry["type"] == "symlink" and entry.get("owned") and entry.get("dangling"):
+            to_prune.append(name)
+    return to_link, to_prune, warnings

--- a/pkgs/python-packages/flasks/rankserver/rankserver.py
+++ b/pkgs/python-packages/flasks/rankserver/rankserver.py
@@ -510,6 +510,99 @@ def set_rankables_dir():
     except Exception as e:
         return flask.jsonify({'success': False, 'error': str(e)}), 500
 
+def _count_owned_links(stamp_dir):
+    stamp_real = os.path.realpath(stamp_dir)
+    count = 0
+    for name in os.listdir(RES_DIR):
+        full = os.path.join(RES_DIR, name)
+        if os.path.islink(full):
+            target = os.readlink(full)
+            if not os.path.isabs(target):
+                target = os.path.join(os.path.dirname(full), target)
+            if os.path.realpath(os.path.dirname(target)) == stamp_real:
+                count += 1
+    return count
+
+
+@bp.route("/api/watch-config", methods=["GET"])
+@flask_login.login_required
+def watch_config():
+    cfg, err = load_config()
+    watch = cfg.get("watch")
+    linked = _count_owned_links(watch["stamp_dir"]) if watch else 0
+    ins = cfg.get("insertions") or {}
+    queue_len = len(ins.get("queue", [])) + (1 if ins.get("active") else 0)
+    return flask.jsonify({"watch": watch, "linked_count": linked,
+                          "queue_len": queue_len, "error": err})
+
+
+@bp.route("/api/set-watch-config", methods=["POST"])
+@flask_login.login_required
+def set_watch_config():
+    data = flask.request.get_json(silent=True) or {}
+    # Guard the raw value: normpath("") is "." (the server CWD), which would
+    # slip past an isdir check.
+    raw_dir = data.get("stamp_dir") or ""
+    tag = (data.get("stamp_tag") or "").strip()
+    if not raw_dir:
+        return flask.jsonify({"success": False, "error": "Missing stamp path"}), 400
+    stamp_dir = os.path.normpath(raw_dir)
+    if not os.path.isdir(stamp_dir):
+        return flask.jsonify({"success": False, "error": "Stamp path is not a directory"}), 400
+    if not tag:
+        return flask.jsonify({"success": False, "error": "Missing stamp tag"}), 400
+    cfg, _ = load_config()
+    cfg["watch"] = {"stamp_dir": stamp_dir, "stamp_tag": tag}
+    cfg.setdefault("insertions", {"queue": [], "active": None})
+    save_config(cfg)
+    warnings = sync_symlinks(cfg)
+    return flask.jsonify({"success": True,
+                          "linked_count": _count_owned_links(stamp_dir),
+                          "warnings": warnings})
+
+
+@bp.route("/api/clear-watch-config", methods=["POST"])
+@flask_login.login_required
+def clear_watch_config():
+    cfg, _ = load_config()
+    cfg.pop("watch", None)
+    save_config(cfg)
+    return flask.jsonify({"success": True})
+
+
+@bp.route("/api/list-stamps", methods=["POST"])
+@flask_login.login_required
+def list_stamps():
+    data = flask.request.get_json(silent=True) or {}
+    raw_path = data.get("path") or ""
+    if not raw_path:
+        return flask.jsonify({"error": "Missing path"}), 400
+    path = os.path.normpath(raw_path)
+    try:
+        return flask.jsonify({"tags": rankops.scan_stamps(os.listdir(path))})
+    except PermissionError:
+        return flask.jsonify({"error": "Permission denied"}), 403
+    except (FileNotFoundError, NotADirectoryError):
+        return flask.jsonify({"error": "Path not found"}), 404
+
+
+@bp.route("/api/make-dir", methods=["POST"])
+@flask_login.login_required
+def make_dir():
+    data = flask.request.get_json(silent=True) or {}
+    path = data.get("path")
+    name = (data.get("name") or "").strip()
+    if (not path or not name or "/" in name or "\\" in name
+            or "\x00" in name or name in (".", "..")):
+        return flask.jsonify({"success": False, "error": "Invalid path or name"}), 400
+    target = os.path.join(os.path.normpath(path), name)
+    try:
+        os.mkdir(target)
+        return flask.jsonify({"success": True, "path": target})
+    except OSError as e:
+        return flask.jsonify({"success": False, "error": str(e)}), 500
+
+
 @bp.route("/thumb/<path:filename>", methods=["GET"])
 @flask_login.login_required
 def thumb(filename):

--- a/pkgs/python-packages/flasks/rankserver/rankserver.py
+++ b/pkgs/python-packages/flasks/rankserver/rankserver.py
@@ -19,6 +19,7 @@ from pysorting import (
     sortStateFromDisk,
     restfulQuickSort,
 )
+import rankops
 
 UINT32_MAX = 0xffffffff
 LOGNAME = "sort_state.log"
@@ -85,6 +86,95 @@ DEFAULT_TARGET = os.path.realpath(RES_DIR)
 # scan of RES_DIR never picks it up.
 THUMB_CACHE = os.path.join(RES_DIR, ".rankthumbs")
 
+
+def load_config():
+    """Read rank_config.json from the active data dir. Returns (cfg, warning)."""
+    path = os.path.join(RES_DIR, rankops.CONFIG_NAME)
+    if not os.path.exists(path):
+        return {"version": 1}, None
+    try:
+        with open(path) as f:
+            return json.load(f), None
+    except (OSError, json.JSONDecodeError) as e:
+        # Report but never clobber a corrupt config file.
+        return {"version": 1}, "rank_config.json unreadable ({}); watch disabled".format(e)
+
+
+def save_config(cfg):
+    path = os.path.join(RES_DIR, rankops.CONFIG_NAME)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(cfg, f, indent=2)
+    os.replace(tmp, path)
+
+
+def _data_dir_entries(stamp_real):
+    """Classify data-dir entries for rankops.plan_sync. A symlink is 'owned'
+    when its target's parent directory resolves into the watched stamp dir."""
+    entries = {}
+    for name in os.listdir(RES_DIR):
+        full = os.path.join(RES_DIR, name)
+        if os.path.islink(full):
+            target = os.readlink(full)
+            if not os.path.isabs(target):
+                target = os.path.join(os.path.dirname(full), target)
+            entries[name] = {
+                "type": "symlink",
+                "owned": os.path.realpath(os.path.dirname(target)) == stamp_real,
+                "dangling": not os.path.exists(full),
+            }
+        elif os.path.isdir(full):
+            entries[name] = {"type": "dir"}
+        else:
+            entries[name] = {"type": "file"}
+    return entries
+
+
+def sync_symlinks(cfg):
+    """Mirror tag-matching stamp files into RES_DIR as symlinks; prune owned
+    dangling links. Returns a list of warning strings. Never raises."""
+    watch = cfg.get("watch")
+    if not watch:
+        return []
+    stamp_dir = watch.get("stamp_dir", "")
+    tag = watch.get("stamp_tag", "")
+    if not stamp_dir or not tag:
+        return ["watch config incomplete; sync skipped"]
+    try:
+        stamp_files = os.listdir(stamp_dir)
+    except OSError as e:
+        # A vanished source must not tear down the working set.
+        return ["stamp dir unreadable ({}); sync skipped".format(e)]
+    stamp_real = os.path.realpath(stamp_dir)
+    to_link, to_prune, warnings = rankops.plan_sync(
+        stamp_files, _data_dir_entries(stamp_real), tag)
+    for name in to_link:
+        try:
+            os.symlink(os.path.join(stamp_real, name), os.path.join(RES_DIR, name))
+        except OSError as e:
+            warnings.append("link failed for {}: {}".format(name, e))
+    for name in to_prune:
+        try:
+            os.unlink(os.path.join(RES_DIR, name))
+        except OSError as e:
+            warnings.append("prune failed for {}: {}".format(name, e))
+    return warnings
+
+
+def state_to_dict(s):
+    return {"sorted": s.sorted, "n": s.n, "arr": list(s.arr),
+            "stack": list(s.stack), "top": s.top, "p": s.p, "i": s.i,
+            "j": s.j, "l": s.l, "c": s.c}
+
+
+def dict_to_state(d):
+    s = QuickSortState()
+    s.sorted = d["sorted"]; s.n = d["n"]; s.arr = list(d["arr"])
+    s.stack = list(d["stack"]); s.top = d["top"]; s.p = d["p"]
+    s.i = d["i"]; s.j = d["j"]; s.l = d["l"]; s.c = d["c"]
+    return s
+
+
 app = flask.Flask(__name__, static_url_path=args.subdomain, static_folder=RES_DIR)
 app.secret_key = _secrets["secret_key"].encode()
 app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=20)
@@ -98,19 +188,39 @@ class RankServer:
         self.state = None
         self.rank_list = []
         self.rev_rank_list = []
+        self.config = {"version": 1}
+        self.insertions = {"queue": [], "active": None}
+        self.warnings = []
 
     def load(self):
+        self.warnings = []
         if not os.path.isdir(RES_DIR):
             return (False, f"Data directory non-existent or broken: {RES_DIR}")
-        files = []
-        for file in os.listdir(RES_DIR):
-            if file.endswith(".txt") or file.endswith(".png") or file.endswith(".mp4"):
-                files.append(file)
+        cfg, cfg_warn = load_config()
+        self.config = cfg
+        if cfg_warn:
+            self.warnings.append(cfg_warn)
+        self.warnings += sync_symlinks(cfg)
+        raw_ins = cfg.get("insertions") or {}
+        self.insertions = {"queue": list(raw_ins.get("queue", [])),
+                           "active": raw_ins.get("active")}
+        files = [f.strip() for f in os.listdir(RES_DIR) if rankops.is_rankable(f)]
         if len(files) == 0:
             return (False, "Data directory has no rankable files (.txt|.png|.mp4)")
         self.mapfilename = os.path.join(RES_DIR, MAPNAME)
-        if not os.path.exists(self.mapfilename):
+        self.logfilename = os.path.join(RES_DIR, LOGNAME)
+        if not os.path.exists(self.mapfilename) or not os.path.exists(self.logfilename):
+            # Fresh init: everything currently present becomes the settled set.
             self.file_map = files
+            if self.insertions["queue"] or self.insertions["active"]:
+                self.insertions = {"queue": [], "active": None}
+                cfg["insertions"] = self.insertions
+                save_config(cfg)
+            self.state = QuickSortState()
+            self.state.n = len(self.file_map)
+            self.state.arr = [i for i in range(self.state.n)]
+            self.state.stack = [0 for _ in range(self.state.n)]
+            self.submitChoice(0)
         else:
             self.file_map = []
             with open(self.mapfilename, "r") as mapfile:
@@ -119,19 +229,44 @@ class RankServer:
                         self.file_map.append(file.strip())
             if len(self.file_map) == 0:
                 return (False, "Empty file map in provided data dir")
-            # TODO check for incongruencies
-        self.logfilename = os.path.join(RES_DIR, LOGNAME)
-        if not os.path.exists(self.logfilename):
-            self.state = QuickSortState()
-            self.state.n = len(self.file_map)
-            self.state.arr = [i for i in range(self.state.n)]
-            self.state.stack = [0 for _ in range(self.state.n)]
-            self.submitChoice(0)
-        else:
             res, self.state = sortStateFromDisk(self.logfilename)
             if not res:
                 return (False, "Sort state loading from file failed")
-            # TODO check for incongruencies
+            d, fmap, ins, result = rankops.reconcile(
+                state_to_dict(self.state), self.file_map, set(files),
+                self.insertions)
+            if result["reset_all"]:
+                os.remove(self.mapfilename)
+                os.remove(self.logfilename)
+                cfg["insertions"] = {"queue": [], "active": None}
+                save_config(cfg)
+                # The recursive load() resets self.warnings; keep this pass's
+                # sync/config warnings visible alongside the fresh init's.
+                carried = self.warnings
+                res = self.load()
+                self.warnings = carried + self.warnings
+                return res
+            if result["changed"]:
+                ok, msg = rankops.validate_state(d, fmap)
+                if not ok:
+                    return (False,
+                            "Sort state reconciliation failed ({}); on-disk "
+                            "state left untouched. Delete {} and {} in the "
+                            "data dir to reset the ranking.".format(
+                                msg, LOGNAME, MAPNAME))
+                self.state = dict_to_state(d)
+                self.file_map = fmap
+                sres, smsg = self.save()
+                if not sres:
+                    return (False, smsg)
+                if result["partitions_restarted"]:
+                    self.warnings.append(
+                        "Removed file(s) overlapped the comparison in progress; "
+                        "the current round was restarted")
+            if ins != self.insertions:
+                cfg["insertions"] = ins
+                save_config(cfg)
+            self.insertions = ins
         self.rank_list = []
         for idx in self.state.arr:
             self.rank_list.append(self.file_map[idx])
@@ -241,21 +376,22 @@ def index():
         rankserver.save()
     
     res, msg = rankserver.load()
+    warn = " | ".join(rankserver.warnings)
     if not res:
-        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=True, done=False, msg=msg, rlist=[], l="", r="")
+        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=True, done=False, msg=msg, rlist=[], l="", r="", warn=warn)
     rlist = rankserver.getRankList()
     if rankserver.sortingComplete():
-        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=False, done=True, msg="", rlist=rlist, l="", r="")
+        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=False, done=True, msg="", rlist=rlist, l="", r="", warn=warn)
     else:
         l, r = rankserver.getCompFiles()
-        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=False, done=False, msg="", rlist=rlist, l=l, r=r)
+        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=False, done=False, msg="", rlist=rlist, l=l, r=r, warn=warn)
 
 @bp.route("/intro", methods=["GET"])
 @flask_login.login_required
 def intro():
     global urlroot
     global SHORT_RESDIR
-    return flask.render_template("index.html", urlroot=urlroot, intro=True, datadir=SHORT_RESDIR, err=False, done=False, msg="", rlist=[], l="", r="")
+    return flask.render_template("index.html", urlroot=urlroot, intro=True, datadir=SHORT_RESDIR, err=False, done=False, msg="", rlist=[], l="", r="", warn="")
 
 @bp.route("/api/rankables-info", methods=["GET"])
 @flask_login.login_required

--- a/pkgs/python-packages/flasks/rankserver/rankserver.py
+++ b/pkgs/python-packages/flasks/rankserver/rankserver.py
@@ -324,6 +324,44 @@ class RankServer:
             return (False, "Failed to persist sort state to disk")
         return (True, "")
 
+    def insertionPending(self):
+        return bool(self.insertions.get("queue") or self.insertions.get("active"))
+
+    def insertionActive(self):
+        return self.insertions.get("active") is not None
+
+    def activateNextInsertion(self):
+        ins = self.insertions
+        fname = ins["queue"].pop(0)
+        ins["active"] = {"file": fname, "lo": 0, "hi": self.state.n}
+        self.config["insertions"] = ins
+        save_config(self.config)
+
+    def insertionCompFiles(self):
+        a = self.insertions["active"]
+        mid = rankops.insertion_mid(a)
+        return (a["file"], self.file_map[self.state.arr[mid]])
+
+    def submitInsertionChoice(self, prefer_new):
+        a = self.insertions["active"]
+        b = rankops.insertion_step(a, prefer_new)
+        a["lo"], a["hi"] = b["lo"], b["hi"]
+        if rankops.insertion_done(a):
+            d, fmap = rankops.insertion_complete(
+                state_to_dict(self.state), self.file_map, a["file"], a["lo"])
+            self.state = dict_to_state(d)
+            self.file_map = fmap
+            sres, smsg = self.save()
+            if not sres:
+                # Persist nothing: the next load() re-reads the old on-disk
+                # state and the unchanged config, so this tap is simply asked
+                # again instead of silently re-queueing or double-inserting.
+                return (False, "insertion save failed: {}".format(smsg))
+            self.insertions["active"] = None
+        self.config["insertions"] = self.insertions
+        save_config(self.config)
+        return (True, "")
+
 rankserver = RankServer()
 
 @login_manager.user_loader
@@ -365,33 +403,63 @@ def index():
     global args
     global rankserver
     global urlroot
+    post_err = ""
     if flask.request.method == "POST":
-        if rankserver.sortingComplete():
-            rankserver.resetState()
+        if rankserver.insertionActive():
+            ires, imsg = rankserver.submitInsertionChoice(
+                "choose_l" in flask.request.form)
+            if not ires:
+                post_err = imsg
+        elif rankserver.sortingComplete():
+            if not rankserver.insertionPending():
+                rankserver.resetState()
+                rankserver.save()
         else:
             if "choose_l" in flask.request.form:
                 rankserver.submitChoice(int(ComparatorResult.LEFT_GREATER))
             else:
                 rankserver.submitChoice(int(ComparatorResult.LEFT_LESS))
-        rankserver.save()
-    
+            rankserver.save()
+
     res, msg = rankserver.load()
+    if post_err:
+        # load() rebuilt self.warnings; re-attach the POST-time failure.
+        rankserver.warnings.append(post_err)
     warn = " | ".join(rankserver.warnings)
     if not res:
-        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=True, done=False, msg=msg, rlist=[], l="", r="", warn=warn)
+        return flask.render_template("index.html", urlroot=urlroot, intro=False,
+                                     datadir=SHORT_RESDIR, err=True, done=False,
+                                     msg=msg, rlist=[], l="", r="", warn=warn,
+                                     insert_note="")
     rlist = rankserver.getRankList()
     if rankserver.sortingComplete():
-        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=False, done=True, msg="", rlist=rlist, l="", r="", warn=warn)
-    else:
-        l, r = rankserver.getCompFiles()
-        return flask.render_template("index.html", urlroot=urlroot, intro=False, datadir=SHORT_RESDIR, err=False, done=False, msg="", rlist=rlist, l=l, r=r, warn=warn)
+        if rankserver.insertionPending():
+            if not rankserver.insertionActive():
+                rankserver.activateNextInsertion()
+            l, r = rankserver.insertionCompFiles()
+            note = "Placing new file — {} more in queue".format(
+                len(rankserver.insertions["queue"]))
+            return flask.render_template("index.html", urlroot=urlroot,
+                                         intro=False, datadir=SHORT_RESDIR,
+                                         err=False, done=False, msg="",
+                                         rlist=rlist, l=l, r=r, warn=warn,
+                                         insert_note=note)
+        return flask.render_template("index.html", urlroot=urlroot, intro=False,
+                                     datadir=SHORT_RESDIR, err=False, done=True,
+                                     msg="", rlist=rlist, l="", r="", warn=warn,
+                                     insert_note="")
+    l, r = rankserver.getCompFiles()
+    return flask.render_template("index.html", urlroot=urlroot, intro=False,
+                                 datadir=SHORT_RESDIR, err=False, done=False,
+                                 msg="", rlist=rlist, l=l, r=r, warn=warn,
+                                 insert_note="")
 
 @bp.route("/intro", methods=["GET"])
 @flask_login.login_required
 def intro():
     global urlroot
     global SHORT_RESDIR
-    return flask.render_template("index.html", urlroot=urlroot, intro=True, datadir=SHORT_RESDIR, err=False, done=False, msg="", rlist=[], l="", r="", warn="")
+    return flask.render_template("index.html", urlroot=urlroot, intro=True, datadir=SHORT_RESDIR, err=False, done=False, msg="", rlist=[], l="", r="", warn="", insert_note="")
 
 @bp.route("/api/rankables-info", methods=["GET"])
 @flask_login.login_required

--- a/pkgs/python-packages/flasks/rankserver/setup.py
+++ b/pkgs/python-packages/flasks/rankserver/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 setup(
     name='rankserver',
     version='0.0.0',
-    py_modules=['rankserver'],
+    py_modules=['rankserver', 'rankops'],
     entry_points={
         'console_scripts': ['rankserver = rankserver:run']
     },

--- a/pkgs/python-packages/flasks/rankserver/tests/test_rankops.py
+++ b/pkgs/python-packages/flasks/rankserver/tests/test_rankops.py
@@ -1,0 +1,60 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import rankops
+
+
+def test_scan_stamps_counts_rankable_only():
+    listing = [
+        "stamped.a.x.png", "stamped.a.y.mp4", "stamped.a.z.jpg",
+        "stamped.b.q.txt", "plain.png", "file_map.log",
+    ]
+    result = rankops.scan_stamps(listing)
+    assert result == {"a": 2, "b": 1}
+    assert list(result.keys()) == ["a", "b"]  # sorted by count desc
+
+
+def test_scan_stamps_empty():
+    assert rankops.scan_stamps(["plain.png", "x.jpg"]) == {}
+
+
+def test_plan_sync_links_missing_matches():
+    to_link, to_prune, warns = rankops.plan_sync(
+        ["stamped.t.a.png", "stamped.t.b.mp4", "stamped.u.c.png", "stamped.t.d.jpg"],
+        {}, "t")
+    assert to_link == ["stamped.t.a.png", "stamped.t.b.mp4"]
+    assert to_prune == []
+    assert warns == []
+
+
+def test_plan_sync_skips_already_linked():
+    entries = {"stamped.t.a.png": {"type": "symlink", "owned": True, "dangling": False}}
+    to_link, to_prune, warns = rankops.plan_sync(["stamped.t.a.png"], entries, "t")
+    assert to_link == [] and to_prune == [] and warns == []
+
+
+def test_plan_sync_prunes_owned_dangling_only():
+    entries = {
+        "stamped.t.a.png": {"type": "symlink", "owned": True, "dangling": True},
+        "stamped.t.b.png": {"type": "symlink", "owned": True, "dangling": False},
+        "foreign.png": {"type": "symlink", "owned": False, "dangling": True},
+        "regular.png": {"type": "file"},
+        "somedir": {"type": "dir"},
+    }
+    to_link, to_prune, warns = rankops.plan_sync([], entries, "t")
+    assert to_prune == ["stamped.t.a.png"]
+    assert to_link == [] and warns == []
+
+
+def test_plan_sync_prunes_owned_dangling_across_tags():
+    # Ownership is stamp-dir-based, not tag-based: a dangling link left by a
+    # different (or former) tag is still cleaned up.
+    entries = {"stamped.other.x.png": {"type": "symlink", "owned": True, "dangling": True}}
+    to_link, to_prune, warns = rankops.plan_sync([], entries, "t")
+    assert to_prune == ["stamped.other.x.png"]
+
+
+def test_plan_sync_warns_on_blocking_regular_file():
+    entries = {"stamped.t.a.png": {"type": "file"}}
+    to_link, to_prune, warns = rankops.plan_sync(["stamped.t.a.png"], entries, "t")
+    assert to_link == []
+    assert len(warns) == 1 and "stamped.t.a.png" in warns[0]

--- a/pkgs/python-packages/flasks/rankserver/tests/test_rankops.py
+++ b/pkgs/python-packages/flasks/rankserver/tests/test_rankops.py
@@ -58,3 +58,107 @@ def test_plan_sync_warns_on_blocking_regular_file():
     to_link, to_prune, warns = rankops.plan_sync(["stamped.t.a.png"], entries, "t")
     assert to_link == []
     assert len(warns) == 1 and "stamped.t.a.png" in warns[0]
+
+
+UMAX = rankops.UINT32_MAX
+
+
+def _mid_state():
+    # n=6; pending ranges (0,2) and active (4,5); positions 3 is final.
+    # Fresh active partition: p=high=5, i=low-1=3, j=low=4, l=J(1), c=0.
+    return (
+        {"sorted": 0, "n": 6, "arr": [5, 2, 0, 1, 3, 4],
+         "stack": [0, 2, 4, 5, 0, 0], "top": 3,
+         "p": 5, "i": 3, "j": 4, "l": 1, "c": 0},
+        ["f0", "f1", "f2", "f3", "f4", "f5"],
+    )
+
+
+def test_remove_outside_active_preserves_progress():
+    state, fmap = _mid_state()
+    # remove pos=1 (arr[1] == 2 -> file f2): inside pending (0,2), not active
+    s2, m2, restarted = rankops.remove_index(state, fmap, 2)
+    assert not restarted
+    assert m2 == ["f0", "f1", "f3", "f4", "f5"]
+    assert s2["n"] == 5
+    assert s2["arr"] == [4, 0, 1, 2, 3]          # popped pos1, values >2 shifted
+    assert s2["stack"][:4] == [0, 1, 3, 4]        # (0,2)->(0,1), (4,5)->(3,4)
+    assert s2["top"] == 3
+    assert (s2["p"], s2["i"], s2["j"]) == (4, 2, 3)  # cursors shifted with range
+    assert (s2["l"], s2["c"]) == (1, 0)              # comparator handshake kept
+    assert len(s2["stack"]) == 5
+    # inputs untouched (contents, not just sizes)
+    assert state["arr"] == [5, 2, 0, 1, 3, 4]
+    assert state["stack"] == [0, 2, 4, 5, 0, 0]
+    assert state["n"] == 6
+    assert fmap == ["f0", "f1", "f2", "f3", "f4", "f5"]
+
+
+def test_remove_finalized_element_preserves_progress():
+    state, fmap = _mid_state()
+    # k=1 -> pos=3: outside pending (0,2) AND active (4,5) (a finalized
+    # position). Exercises the m == 0 branch of the cursor restore.
+    s2, m2, restarted = rankops.remove_index(state, fmap, 1)
+    assert not restarted
+    assert m2 == ["f0", "f2", "f3", "f4", "f5"]
+    assert s2["arr"] == [4, 1, 0, 2, 3]
+    assert s2["stack"][:4] == [0, 2, 3, 4] and s2["top"] == 3
+    assert (s2["p"], s2["i"], s2["j"]) == (4, 2, 3)
+    assert (s2["l"], s2["c"]) == (1, 0)
+
+
+def test_remove_inside_active_restarts_partition_only():
+    state, fmap = _mid_state()
+    # remove pos=4 (arr[4] == 3 -> f3): inside active (4,5) -> pair drops to
+    # singleton, next pair (0,2) becomes active and is restarted.
+    s2, m2, restarted = rankops.remove_index(state, fmap, 3)
+    assert restarted
+    assert s2["n"] == 5
+    assert s2["arr"] == [4, 2, 0, 1, 3]
+    assert s2["stack"][:2] == [0, 2] and s2["top"] == 1
+    assert (s2["p"], s2["i"], s2["j"]) == (2, UMAX, 0)  # resetPartition, low==0 wrap
+    assert (s2["l"], s2["c"]) == (1, 0)
+    assert s2["sorted"] == 0
+
+
+def test_remove_last_pending_pair_completes_sort():
+    # k=0 puts the removal at the active range's HIGH boundary (pos == high),
+    # exercising the high >= pos shift rule.
+    state = {"sorted": 0, "n": 2, "arr": [1, 0], "stack": [0, 1], "top": 1,
+             "p": 1, "i": UMAX, "j": 0, "l": 1, "c": 0}
+    s2, m2, restarted = rankops.remove_index(state, ["a", "b"], 0)
+    assert s2["sorted"] == 1
+    assert s2["n"] == 1 and s2["arr"] == [0] and m2 == ["b"]
+    assert s2["top"] == UMAX
+    assert not restarted  # sort completed; no comparisons were discarded
+
+
+def test_remove_from_sorted_state():
+    state = {"sorted": 1, "n": 3, "arr": [2, 0, 1], "stack": [0, 0, 0],
+             "top": UMAX, "p": 0, "i": 0, "j": 0, "l": 1, "c": 0}
+    s2, m2, restarted = rankops.remove_index(state, ["a", "b", "c"], 0)
+    assert not restarted
+    assert s2["sorted"] == 1 and s2["n"] == 2
+    assert s2["arr"] == [1, 0] and m2 == ["b", "c"]
+    assert s2["stack"] == [0, 0] and s2["top"] == UMAX
+
+
+def test_validate_accepts_produced_states():
+    state, fmap = _mid_state()
+    ok, msg = rankops.validate_state(state, fmap)
+    assert ok, msg
+    for k in (2, 3):
+        s2, m2, _ = rankops.remove_index(state, fmap, k)
+        ok, msg = rankops.validate_state(s2, m2)
+        assert ok, msg
+
+
+def test_validate_rejects_malformed():
+    state, fmap = _mid_state()
+    bad = dict(state, arr=[0, 0, 1, 2, 3, 4])
+    assert not rankops.validate_state(bad, fmap)[0]
+    bad = dict(state, sorted=1)                      # sorted but top != UMAX
+    assert not rankops.validate_state(bad, fmap)[0]
+    bad = dict(state, p=4)                           # pivot not at range high
+    assert not rankops.validate_state(bad, fmap)[0]
+    assert not rankops.validate_state(state, fmap[:-1])[0]  # map length mismatch

--- a/pkgs/python-packages/flasks/rankserver/tests/test_rankops.py
+++ b/pkgs/python-packages/flasks/rankserver/tests/test_rankops.py
@@ -162,3 +162,108 @@ def test_validate_rejects_malformed():
     bad = dict(state, p=4)                           # pivot not at range high
     assert not rankops.validate_state(bad, fmap)[0]
     assert not rankops.validate_state(state, fmap[:-1])[0]  # map length mismatch
+
+
+def _sorted_state():
+    return (
+        {"sorted": 1, "n": 4, "arr": [3, 1, 0, 2], "stack": [0, 0, 0, 0],
+         "top": UMAX, "p": 0, "i": 0, "j": 0, "l": 1, "c": 0},
+        ["f0", "f1", "f2", "f3"],
+    )
+
+
+def _no_insertions():
+    return {"queue": [], "active": None}
+
+
+def test_reconcile_queues_new_files_sorted():
+    state, fmap = _sorted_state()
+    present = set(fmap) | {"new_b.png", "new_a.png"}
+    s2, m2, ins2, res = rankops.reconcile(state, fmap, present, _no_insertions())
+    assert ins2["queue"] == ["new_a.png", "new_b.png"]
+    assert not res["changed"] and not res["reset_all"]
+    assert m2 == fmap
+
+
+def test_reconcile_dedupes_known_files():
+    state, fmap = _sorted_state()
+    ins = {"queue": ["q.png"], "active": {"file": "a.png", "lo": 1, "hi": 3}}
+    present = set(fmap) | {"q.png", "a.png"}
+    s2, m2, ins2, res = rankops.reconcile(state, fmap, present, ins)
+    assert ins2["queue"] == ["q.png"]
+    assert ins2["active"]["file"] == "a.png"
+
+
+def test_reconcile_removes_missing_and_shifts_active_bounds():
+    state, fmap = _sorted_state()
+    ins = {"queue": [], "active": {"file": "a.png", "lo": 2, "hi": 4}}
+    present = (set(fmap) - {"f1"}) | {"a.png"}   # f1 sits at arr pos 1
+    s2, m2, ins2, res = rankops.reconcile(state, fmap, present, ins)
+    assert res["changed"] and not res["reset_all"]
+    assert m2 == ["f0", "f2", "f3"]
+    assert s2["n"] == 3
+    assert ins2["active"] == {"file": "a.png", "lo": 1, "hi": 3}
+    ok, msg = rankops.validate_state(s2, m2)
+    assert ok, msg
+
+
+def test_reconcile_mid_sort_removal_counts_restart_and_shifts_bounds():
+    state, fmap = _mid_state()
+    # f3 sits inside the active partition (arr pos 4): its removal restarts
+    # that partition; the active insertion's bounds shift past pos 4.
+    ins = {"queue": [], "active": {"file": "a.png", "lo": 5, "hi": 6}}
+    present = (set(fmap) - {"f3"}) | {"a.png"}
+    s2, m2, ins2, res = rankops.reconcile(state, fmap, present, ins)
+    assert res["changed"] and res["partitions_restarted"] == 1
+    assert m2 == ["f0", "f1", "f2", "f4", "f5"]
+    assert ins2["active"] == {"file": "a.png", "lo": 4, "hi": 5}
+    assert ins == {"queue": [], "active": {"file": "a.png", "lo": 5, "hi": 6}}
+    ok, msg = rankops.validate_state(s2, m2)
+    assert ok, msg
+
+
+def test_reconcile_drops_vanished_queue_and_active():
+    state, fmap = _sorted_state()
+    ins = {"queue": ["gone.png"], "active": {"file": "also_gone.png", "lo": 0, "hi": 4}}
+    s2, m2, ins2, res = rankops.reconcile(state, fmap, set(fmap), ins)
+    assert ins2 == {"queue": [], "active": None}
+
+
+def test_reconcile_reset_all_when_settled_set_empties():
+    state = {"sorted": 1, "n": 1, "arr": [0], "stack": [0], "top": UMAX,
+             "p": 0, "i": 0, "j": 0, "l": 1, "c": 0}
+    s2, m2, ins2, res = rankops.reconcile(state, ["only.png"], {"other.png"},
+                                          _no_insertions())
+    assert res["reset_all"]
+    assert m2 == [] and ins2 == {"queue": [], "active": None}
+
+
+def test_insertion_binary_search_converges_high():
+    b = {"lo": 0, "hi": 4}
+    while not rankops.insertion_done(b):
+        b = rankops.insertion_step(b, prefer_new=True)
+    assert b["lo"] == 4  # always preferred -> inserts at the top
+
+
+def test_insertion_binary_search_converges_low():
+    b = {"lo": 0, "hi": 4}
+    while not rankops.insertion_done(b):
+        b = rankops.insertion_step(b, prefer_new=False)
+    assert b["lo"] == 0
+
+
+def test_insertion_step_moves_correct_bound():
+    b = rankops.insertion_step({"lo": 0, "hi": 5}, prefer_new=True)
+    assert b == {"lo": 3, "hi": 5}   # mid=2, new preferred -> after mid
+    b = rankops.insertion_step({"lo": 0, "hi": 5}, prefer_new=False)
+    assert b == {"lo": 0, "hi": 2}
+
+
+def test_insertion_complete_places_file():
+    state, fmap = _sorted_state()
+    s2, m2 = rankops.insertion_complete(state, fmap, "new.png", 2)
+    assert m2 == ["f0", "f1", "f2", "f3", "new.png"]
+    assert s2["arr"] == [3, 1, 4, 0, 2]   # new index 4 spliced at pos 2
+    assert s2["n"] == 5 and len(s2["stack"]) == 5 and s2["top"] == UMAX
+    ok, msg = rankops.validate_state(s2, m2)
+    assert ok, msg


### PR DESCRIPTION
Rankserver can now "watch" a stampserver directory: a per-data-dir `rank_config.json` (configured from the intro page) names a reference stamp dir and a stamp tag, and rankserver maintains symlinks to matching `stamped.<tag>.*` files automatically — creating links for newly stamped files on every page load and pruning links whose stamp-dir targets have been deleted or restamped away.

The quicksort ranking state is now robust to the file set changing between loads:

- **Removals** are absorbed by surgically remapping the persisted `QuickSortState` (arr/stack/cursor index shifts in a new pure-Python `rankops` module). All comparison work survives except when the removed file sat inside the active partition, in which case only that partition restarts. State surgery is validate-or-abort: on any inconsistency the on-disk state is left untouched and the UI offers an explicit reset.
- **Additions** queue in `rank_config.json` until the in-flight base sort completes, then each queued file is placed into the finished ranking by binary insertion (~log2(n) taps per file), with bounds persisted after every tap.

UI: new Stamp Watch card on the directory page (scanned tag dropdown with per-tag file counts, configure/clear), "+ New Folder" button in the shared dir picker, and a warning banner surfacing sync/reconcile issues. Five new authenticated API endpoints back these (`watch-config` get/set/clear, `list-stamps`, `make-dir`).

`rankops.py` is stdlib-only pure functions with a 24-test pytest suite wired into the nix build via `pytestCheckHook`. Plain directories without `rank_config.json` behave exactly as before; `file_map.log`/`sort_state.log` formats and the C++ sorting library are unchanged.

Verified end-to-end against a local instance: initial sync, mid-sort stamping (queues without disturbing the sort), binary insertion placement, restamp-away removal with order preservation and no reset, clear-keeps-symlinks, and no-config regression. Deployed and running locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)