### PR TITLE
[fileservers] more preference improvements

### DIFF
--- a/changes/pr-581.md
+++ b/changes/pr-581.md
@@ -1,0 +1,1 @@
+[fileservers] more preference improvements

--- a/pkgs/python-packages/flasks/rankserver/index.html
+++ b/pkgs/python-packages/flasks/rankserver/index.html
@@ -354,6 +354,33 @@
             user-select: none;
         }
 
+        /* Up/down list traversal while zoomed: stacked on the right edge,
+           vertically centered, so they never cover the media's center. */
+        .lightbox-nav {
+            position: absolute;
+            right: 20px;
+            top: 50%;
+            width: 52px;
+            height: 52px;
+            border: none;
+            border-radius: 50%;
+            background-color: rgba(255, 255, 255, 0.18);
+            color: #fff;
+            font-size: 1.4rem;
+            line-height: 1;
+            cursor: pointer;
+            user-select: none;
+            touch-action: manipulation;
+            transition: background-color 0.15s;
+        }
+
+        .lightbox-nav:hover:not(:disabled) { background-color: rgba(255, 255, 255, 0.35); }
+
+        .lightbox-nav:disabled { opacity: 0.25; cursor: default; }
+
+        #lightboxPrev { transform: translateY(-60px); }
+        #lightboxNext { transform: translateY(8px); }
+
         .rank-list .rank-txt {
             font-family: monospace;
             font-weight: 600;
@@ -479,6 +506,24 @@
             min-width: 100px;
         }
 
+        .watch-list {
+            list-style: none;
+            margin: 14px 0 0 0;
+            padding: 0;
+        }
+
+        .watch-list li {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            flex-wrap: wrap;
+            padding: 8px 0;
+        }
+
+        .watch-list li + li {
+            border-top: 1px solid #f1f3f5;
+        }
+
         .start-row {
             margin: 24px 0;
         }
@@ -547,15 +592,15 @@
         <div class="rankables-config">
             <h2>Stamp Watch</h2>
             <p class="help">Optionally mirror files carrying a chosen stamp tag from a
-               stampserver directory into this rankables directory. Symlinks are kept
-               in sync automatically; newly stamped files queue up for placement into
-               the existing ranking.</p>
+               stampserver directory into this rankables directory. Multiple watch
+               targets can be active at once. Symlinks are kept in sync automatically;
+               newly stamped files queue up for placement into the existing ranking.</p>
             <div class="rankables-realpath">
                 <span class="realpath-label">Status:</span>
                 <span class="realpath-value" id="watchStatus">Loading...</span>
-                <button class="btn btn-sm" onclick="openWatchConfig()">Configure&hellip;</button>
-                <button class="btn btn-sm btn-danger" onclick="clearWatchConfig()">Clear</button>
+                <button class="btn btn-sm" onclick="openWatchConfig()">Add&hellip;</button>
             </div>
+            <ul class="watch-list" id="watchList"></ul>
             <div class="rankables-realpath" id="watchTagRow" style="display: none;">
                 <span class="realpath-label">Tag for <span id="watchChosenDir"></span>:</span>
                 <select id="watchTagSelect"></select>
@@ -590,7 +635,7 @@
                     {% if l.endswith('.txt') %}
                     <span class="txt-name">{{ l }}</span>
                     {% elif l.endswith('.mp4') %}
-                    <video src="{{ urlroot }}media/{{ l }}#t=0.001" controls preload="metadata" playsinline></video>
+                    <video src="{{ urlroot }}media/{{ l }}#t=0.001" controls loop preload="metadata" playsinline></video>
                     {% else %}
                     <img src="{{ urlroot }}thumb/{{ l }}?w=1200" decoding="async" alt="" />
                     {% endif %}
@@ -604,7 +649,7 @@
                     {% if r.endswith('.txt') %}
                     <span class="txt-name">{{ r }}</span>
                     {% elif r.endswith('.mp4') %}
-                    <video src="{{ urlroot }}media/{{ r }}#t=0.001" controls preload="metadata" playsinline></video>
+                    <video src="{{ urlroot }}media/{{ r }}#t=0.001" controls loop preload="metadata" playsinline></video>
                     {% else %}
                     <img src="{{ urlroot }}thumb/{{ r }}?w=1200" decoding="async" alt="" />
                     {% endif %}
@@ -642,6 +687,8 @@
     <div class="lightbox" id="lightbox" onclick="closeLightbox()">
         <span class="lightbox-close">&times;</span>
         <div class="lightbox-content" id="lightboxContent"></div>
+        <button class="lightbox-nav" id="lightboxPrev" onclick="lightboxStep(-1, event)" title="Previous (higher rank)">&#9650;</button>
+        <button class="lightbox-nav" id="lightboxNext" onclick="lightboxStep(1, event)" title="Next (lower rank)">&#9660;</button>
     </div>
 
     <script>
@@ -655,38 +702,63 @@
 
         // ===== LIGHTBOX (maximize ranked-list media on click) =====
 
-        function openLightbox(type, src) {
+        // Zoomable ranked-list entries in rank order; the lightbox tracks an
+        // index into this so up/down traverses the list (skipping .txt items,
+        // which have no media to zoom).
+        const rankMedia = Array.from(document.querySelectorAll('.rank-media'));
+        let lightboxIndex = -1;
+
+        function showLightboxItem(index) {
+            const item = rankMedia[index];
             const content = document.getElementById('lightboxContent');
             content.innerHTML = '';
             let el;
-            if (type === 'video') {
+            if (item.dataset.type === 'video') {
                 el = document.createElement('video');
-                el.src = src;
+                el.src = item.dataset.full;
                 el.controls = true;
                 el.autoplay = true;
+                el.loop = true;
                 el.playsInline = true;
             } else {
                 el = document.createElement('img');
-                el.src = src;
+                el.src = item.dataset.full;
             }
             // Clicks on the media itself shouldn't dismiss the overlay (e.g. video
             // controls); dismissal happens by clicking the dark backdrop or close.
             el.addEventListener('click', (e) => e.stopPropagation());
             content.appendChild(el);
+            lightboxIndex = index;
+            document.getElementById('lightboxPrev').disabled = index <= 0;
+            document.getElementById('lightboxNext').disabled = index >= rankMedia.length - 1;
+        }
+
+        function openLightbox(index) {
+            showLightboxItem(index);
             document.getElementById('lightbox').style.display = 'flex';
+        }
+
+        function lightboxStep(delta, e) {
+            e.stopPropagation();
+            const next = lightboxIndex + delta;
+            if (next >= 0 && next < rankMedia.length) showLightboxItem(next);
         }
 
         function closeLightbox() {
             document.getElementById('lightbox').style.display = 'none';
             document.getElementById('lightboxContent').innerHTML = '';
+            lightboxIndex = -1;
         }
 
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') closeLightbox();
+            if (lightboxIndex < 0) return;
+            if (e.key === 'ArrowUp') { e.preventDefault(); lightboxStep(-1, e); }
+            if (e.key === 'ArrowDown') { e.preventDefault(); lightboxStep(1, e); }
         });
 
-        document.querySelectorAll('.rank-media').forEach((el) => {
-            el.addEventListener('click', () => openLightbox(el.dataset.type, el.dataset.full));
+        rankMedia.forEach((el, i) => {
+            el.addEventListener('click', () => openLightbox(i));
         });
 
         // ===== RANKABLES DIR PICKER =====
@@ -852,12 +924,31 @@
                 .then(r => r.json())
                 .then(data => {
                     const el = document.getElementById('watchStatus');
+                    const list = document.getElementById('watchList');
+                    list.innerHTML = '';
                     if (data.error) { el.textContent = data.error; return; }
-                    if (!data.watch) { el.textContent = 'Not watching'; return; }
-                    let txt = 'Watching ' + data.watch.stamp_dir + ' for tag "'
-                        + data.watch.stamp_tag + '" — ' + data.linked_count + ' linked';
+                    if (!data.watches || data.watches.length === 0) {
+                        el.textContent = 'Not watching';
+                        return;
+                    }
+                    let txt = data.watches.length + ' watch target'
+                        + (data.watches.length > 1 ? 's' : '');
                     if (data.queue_len > 0) txt += ' (' + data.queue_len + ' queued)';
                     el.textContent = txt;
+                    data.watches.forEach(w => {
+                        const li = document.createElement('li');
+                        const span = document.createElement('span');
+                        span.className = 'realpath-value';
+                        span.textContent = w.stamp_dir + ' — tag "' + w.stamp_tag
+                            + '" — ' + w.linked_count + ' linked';
+                        const btn = document.createElement('button');
+                        btn.className = 'btn btn-sm btn-danger';
+                        btn.textContent = 'Remove';
+                        btn.onclick = () => removeWatch(w.stamp_dir, w.stamp_tag);
+                        li.appendChild(span);
+                        li.appendChild(btn);
+                        list.appendChild(li);
+                    });
                 })
                 .catch(() => {
                     document.getElementById('watchStatus').textContent = '(error loading)';
@@ -888,7 +979,7 @@
             .then(data => {
                 if (data.success) {
                     cancelWatchConfig();
-                    showStatus('Watch configured; ' + data.linked_count + ' file(s) linked'
+                    showStatus('Watch added; ' + data.linked_count + ' file(s) linked'
                         + (data.warnings && data.warnings.length ? ' — ' + data.warnings.join('; ') : ''));
                     loadWatchInfo();
                 } else {
@@ -898,12 +989,16 @@
             .catch(err => showStatus('Error: ' + err.message, true));
         }
 
-        function clearWatchConfig() {
-            if (!confirm('Stop watching? Existing symlinks are kept.')) return;
-            fetch('{{ urlroot }}api/clear-watch-config', {method: 'POST'})
+        function removeWatch(dir, tag) {
+            if (!confirm('Stop watching ' + dir + ' for tag "' + tag + '"?\nExisting symlinks are kept.')) return;
+            fetch('{{ urlroot }}api/clear-watch-config', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({stamp_dir: dir, stamp_tag: tag})
+            })
             .then(r => r.json())
             .then(data => {
-                if (data.success) { cancelWatchConfig(); showStatus('Watch cleared'); loadWatchInfo(); }
+                if (data.success) { showStatus('Watch removed'); loadWatchInfo(); }
                 else { showStatus('Error: ' + (data.error || 'Unknown error'), true); }
             })
             .catch(err => showStatus('Error: ' + err.message, true));

--- a/pkgs/python-packages/flasks/rankserver/rankops.py
+++ b/pkgs/python-packages/flasks/rankserver/rankops.py
@@ -26,6 +26,16 @@ def is_rankable(name):
     return name.lower().endswith(RANKABLE_EXTS)
 
 
+def get_watches(cfg):
+    """Normalize watch config to a list of {stamp_dir, stamp_tag} dicts.
+    Accepts the current "watches" list or the legacy single-"watch" dict."""
+    watches = cfg.get("watches")
+    if watches is None:
+        legacy = cfg.get("watch")
+        watches = [legacy] if legacy else []
+    return [w for w in watches if isinstance(w, dict)]
+
+
 def stamp_prefix(tag):
     return "stamped.{}.".format(tag)
 

--- a/pkgs/python-packages/flasks/rankserver/rankserver.py
+++ b/pkgs/python-packages/flasks/rankserver/rankserver.py
@@ -108,9 +108,9 @@ def save_config(cfg):
     os.replace(tmp, path)
 
 
-def _data_dir_entries(stamp_real):
+def _data_dir_entries(stamp_reals):
     """Classify data-dir entries for rankops.plan_sync. A symlink is 'owned'
-    when its target's parent directory resolves into the watched stamp dir."""
+    when its target's parent directory resolves into any watched stamp dir."""
     entries = {}
     for name in os.listdir(RES_DIR):
         full = os.path.join(RES_DIR, name)
@@ -120,7 +120,7 @@ def _data_dir_entries(stamp_real):
                 target = os.path.join(os.path.dirname(full), target)
             entries[name] = {
                 "type": "symlink",
-                "owned": os.path.realpath(os.path.dirname(target)) == stamp_real,
+                "owned": os.path.realpath(os.path.dirname(target)) in stamp_reals,
                 "dangling": not os.path.exists(full),
             }
         elif os.path.isdir(full):
@@ -133,27 +133,39 @@ def _data_dir_entries(stamp_real):
 def sync_symlinks(cfg):
     """Mirror tag-matching stamp files into RES_DIR as symlinks; prune owned
     dangling links. Returns a list of warning strings. Never raises."""
-    watch = cfg.get("watch")
-    if not watch:
+    watches = rankops.get_watches(cfg)
+    if not watches:
         return []
-    stamp_dir = watch.get("stamp_dir", "")
-    tag = watch.get("stamp_tag", "")
-    if not stamp_dir or not tag:
-        return ["watch config incomplete; sync skipped"]
-    try:
-        stamp_files = os.listdir(stamp_dir)
-    except OSError as e:
-        # A vanished source must not tear down the working set.
-        return ["stamp dir unreadable ({}); sync skipped".format(e)]
-    stamp_real = os.path.realpath(stamp_dir)
-    to_link, to_prune, warnings = rankops.plan_sync(
-        stamp_files, _data_dir_entries(stamp_real), tag)
-    for name in to_link:
+    warnings = []
+    listings = []  # (stamp_real, stamp_files, tag)
+    for watch in watches:
+        stamp_dir = watch.get("stamp_dir", "")
+        tag = watch.get("stamp_tag", "")
+        if not stamp_dir or not tag:
+            warnings.append("watch config incomplete; sync skipped for one entry")
+            continue
+        try:
+            stamp_files = os.listdir(stamp_dir)
+        except OSError as e:
+            # A vanished source must not tear down the working set.
+            warnings.append("stamp dir unreadable ({}); sync skipped".format(e))
+            continue
+        listings.append((os.path.realpath(stamp_dir), stamp_files, tag))
+    entries = _data_dir_entries({real for real, _, _ in listings})
+    to_link = {}       # name -> stamp_real; first watch to claim a name wins
+    to_prune = set()   # every plan_sync pass proposes the same owned-dangling set
+    for stamp_real, stamp_files, tag in listings:
+        links, prunes, warns = rankops.plan_sync(stamp_files, entries, tag)
+        warnings += warns
+        for name in links:
+            to_link.setdefault(name, stamp_real)
+        to_prune.update(prunes)
+    for name, stamp_real in sorted(to_link.items()):
         try:
             os.symlink(os.path.join(stamp_real, name), os.path.join(RES_DIR, name))
         except OSError as e:
             warnings.append("link failed for {}: {}".format(name, e))
-    for name in to_prune:
+    for name in sorted(to_prune):
         try:
             os.unlink(os.path.join(RES_DIR, name))
         except OSError as e:
@@ -510,10 +522,13 @@ def set_rankables_dir():
     except Exception as e:
         return flask.jsonify({'success': False, 'error': str(e)}), 500
 
-def _count_owned_links(stamp_dir):
+def _count_owned_links(stamp_dir, tag):
     stamp_real = os.path.realpath(stamp_dir)
+    prefix = rankops.stamp_prefix(tag)
     count = 0
     for name in os.listdir(RES_DIR):
+        if not name.startswith(prefix):
+            continue
         full = os.path.join(RES_DIR, name)
         if os.path.islink(full):
             target = os.readlink(full)
@@ -524,16 +539,28 @@ def _count_owned_links(stamp_dir):
     return count
 
 
+def _set_watches(cfg, watches):
+    """Store the normalized watch list, retiring the legacy single-watch key."""
+    if watches:
+        cfg["watches"] = watches
+    else:
+        cfg.pop("watches", None)
+    cfg.pop("watch", None)
+
+
 @bp.route("/api/watch-config", methods=["GET"])
 @flask_login.login_required
 def watch_config():
     cfg, err = load_config()
-    watch = cfg.get("watch")
-    linked = _count_owned_links(watch["stamp_dir"]) if watch else 0
+    watches = [{"stamp_dir": w.get("stamp_dir", ""),
+                "stamp_tag": w.get("stamp_tag", ""),
+                "linked_count": _count_owned_links(w.get("stamp_dir", ""),
+                                                   w.get("stamp_tag", ""))}
+               for w in rankops.get_watches(cfg)]
     ins = cfg.get("insertions") or {}
     queue_len = len(ins.get("queue", [])) + (1 if ins.get("active") else 0)
-    return flask.jsonify({"watch": watch, "linked_count": linked,
-                          "queue_len": queue_len, "error": err})
+    return flask.jsonify({"watches": watches, "queue_len": queue_len,
+                          "error": err})
 
 
 @bp.route("/api/set-watch-config", methods=["POST"])
@@ -552,20 +579,31 @@ def set_watch_config():
     if not tag:
         return flask.jsonify({"success": False, "error": "Missing stamp tag"}), 400
     cfg, _ = load_config()
-    cfg["watch"] = {"stamp_dir": stamp_dir, "stamp_tag": tag}
+    watches = rankops.get_watches(cfg)
+    entry = {"stamp_dir": stamp_dir, "stamp_tag": tag}
+    if entry not in watches:
+        watches.append(entry)
+    _set_watches(cfg, watches)
     cfg.setdefault("insertions", {"queue": [], "active": None})
     save_config(cfg)
     warnings = sync_symlinks(cfg)
     return flask.jsonify({"success": True,
-                          "linked_count": _count_owned_links(stamp_dir),
+                          "linked_count": _count_owned_links(stamp_dir, tag),
                           "warnings": warnings})
 
 
 @bp.route("/api/clear-watch-config", methods=["POST"])
 @flask_login.login_required
 def clear_watch_config():
+    data = flask.request.get_json(silent=True) or {}
     cfg, _ = load_config()
-    cfg.pop("watch", None)
+    watches = rankops.get_watches(cfg)
+    if data.get("stamp_dir") and data.get("stamp_tag"):
+        target = {"stamp_dir": data["stamp_dir"], "stamp_tag": data["stamp_tag"]}
+        watches = [w for w in watches if w != target]
+    else:
+        watches = []
+    _set_watches(cfg, watches)
     save_config(cfg)
     return flask.jsonify({"success": True})
 

--- a/pkgs/python-packages/flasks/rankserver/tests/test_rankops.py
+++ b/pkgs/python-packages/flasks/rankserver/tests/test_rankops.py
@@ -17,6 +17,20 @@ def test_scan_stamps_empty():
     assert rankops.scan_stamps(["plain.png", "x.jpg"]) == {}
 
 
+def test_get_watches_normalizes_legacy_and_list():
+    assert rankops.get_watches({}) == []
+    assert rankops.get_watches({"watch": None}) == []
+    legacy = {"watch": {"stamp_dir": "/s", "stamp_tag": "t"}}
+    assert rankops.get_watches(legacy) == [{"stamp_dir": "/s", "stamp_tag": "t"}]
+    multi = {"watches": [{"stamp_dir": "/a", "stamp_tag": "x"},
+                         {"stamp_dir": "/b", "stamp_tag": "y"}]}
+    assert rankops.get_watches(multi) == multi["watches"]
+    # "watches" takes precedence over a stale legacy key; junk entries dropped
+    both = {"watches": [{"stamp_dir": "/a", "stamp_tag": "x"}, "junk"],
+            "watch": {"stamp_dir": "/old", "stamp_tag": "z"}}
+    assert rankops.get_watches(both) == [{"stamp_dir": "/a", "stamp_tag": "x"}]
+
+
 def test_plan_sync_links_missing_matches():
     to_link, to_prune, warns = rankops.plan_sync(
         ["stamped.t.a.png", "stamped.t.b.mp4", "stamped.u.c.png", "stamped.t.d.jpg"],


### PR DESCRIPTION
Three improvements to rankserver:

- **Loop videos** — comparison-view and lightbox videos now loop, matching stampserver's behavior.
- **Multiple stamp watch targets** — a rank directory can now watch several stampserver dir/tag pairs at once. Config moves from a single `watch` dict to a `watches` list; legacy configs are normalized transparently and migrated on next save. Symlink pruning treats links into *any* watched stamp dir as owned. The intro page shows the watch list with per-target Remove buttons and an Add flow; `clear-watch-config` accepts an optional dir/tag pair to remove a single target.
- **Lightbox list traversal** — the zoomed ranked-item view gains ▲/▼ buttons (and ArrowUp/ArrowDown) to step up and down the ranking without leaving the zoomed view; buttons disable at the list ends.

Tested: rankops unit suite passes (25 tests, incl. new `get_watches` coverage); deployed locally via anix-upgrade and smoke-tested the running service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)