### PR TITLE
nixos-profile-diff: rewrite ssh github URLs to https

### DIFF
--- a/.github/workflows/nixos-profile-diff.yml
+++ b/.github/workflows/nixos-profile-diff.yml
@@ -50,6 +50,9 @@ jobs:
           extra_nix_config: |
             extra-platforms = aarch64-linux
 
+      - run: >
+          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+
       - name: Run profile diff
         run: |
           echo "Base: ${{ steps.refs.outputs.base_sha }}"


### PR DESCRIPTION
The NixOS Profile Diff workflow has been consistently reporting `drone-obc-sitl` as "❌ Eval error on both branches". The root cause (surfaced by temporarily printing eval stderr on PR #582) is:

```
error: Failed to fetch git repository 'ssh://git@github.com/goromal/ardupilot'
```

The `ardupilot` flake input uses a `git+ssh` URL (flake.nix line 22) and only the drone profile forces it during eval; the runner has no SSH credentials, so the fetch fails immediately on both branches. `test.yml` already solves this for its eval jobs with a git `insteadOf` rewrite — this PR applies the same one-liner to the profile-diff workflow. The repo is public and all of its submodules use https URLs, so the anonymous rewrite works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)