### PR TITLE
[ATS] Daily disciple-report survey job

### DIFF
--- a/changes/pr-584.md
+++ b/changes/pr-584.md
@@ -1,0 +1,1 @@
+[ATS] Daily disciple-report survey job

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1783780953,
-        "narHash": "sha256-lbWNExum6ow+7xrwPk+PdevnjlZ3N/8CcD2UYrfGWno=",
+        "lastModified": 1783568221,
+        "narHash": "sha256-DXKwdR4BEIXmaQ4P2UYJ98n0FihFT7ZWyIKlNqJTOWo=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "09080c9915a5c11f8a17bedc90263e1ee644e498",
+        "rev": "861bdc9cde7945bcd725c9849452cd4c2671d888",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1783780506,
-        "narHash": "sha256-Lfj9ye8M+4ub9ZBZ7VEwdO6oiLt5TsZhcaitiRoq4dw=",
+        "lastModified": 1783780953,
+        "narHash": "sha256-lbWNExum6ow+7xrwPk+PdevnjlZ3N/8CcD2UYrfGWno=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "d2db46628ba11a9b0b90be3c0acfd7b78a53c778",
+        "rev": "09080c9915a5c11f8a17bedc90263e1ee644e498",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1783568221,
-        "narHash": "sha256-DXKwdR4BEIXmaQ4P2UYJ98n0FihFT7ZWyIKlNqJTOWo=",
+        "lastModified": 1783780506,
+        "narHash": "sha256-Lfj9ye8M+4ub9ZBZ7VEwdO6oiLt5TsZhcaitiRoq4dw=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "861bdc9cde7945bcd725c9849452cd4c2671d888",
+        "rev": "d2db46628ba11a9b0b90be3c0acfd7b78a53c778",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1783568221,
-        "narHash": "sha256-DXKwdR4BEIXmaQ4P2UYJ98n0FihFT7ZWyIKlNqJTOWo=",
+        "lastModified": 1783784217,
+        "narHash": "sha256-lbWNExum6ow+7xrwPk+PdevnjlZ3N/8CcD2UYrfGWno=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "861bdc9cde7945bcd725c9849452cd4c2671d888",
+        "rev": "00d758eba40e9d7f6037829c531dc7d3505ce21b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A collection of personal (or otherwise personally useful) software packaged in Nix.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?ref=refs/tags/25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=refs/tags/25.11"; 
 
     jetpack-nixos.url = "github:anduril/jetpack-nixos";
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A collection of personal (or otherwise personally useful) software packaged in Nix.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?ref=refs/tags/25.11"; 
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=refs/tags/25.11";
 
     jetpack-nixos.url = "github:anduril/jetpack-nixos";
 

--- a/pkgs/nixos/profiles/ats.nix
+++ b/pkgs/nixos/profiles/ats.nix
@@ -111,6 +111,17 @@ in
           };
         }
         {
+          name = "ats-disciple-report";
+          jobShellScript = pkgs.writeShellScript "ats-disciple-report" ''
+            disciple-report --db-path $HOME/data/disciple/disciple.db || { >&2 logger -t ats-disciple-report "disciple report error!"; exit 1; }
+            logger -t ats-disciple-report "🕮 Disciple study result reported to tactical server"
+          '';
+          timerCfg = {
+            OnCalendar = [ "*-*-* 05:00:00" ];
+            Persistent = true;
+          };
+        }
+        {
           name = "ats-task-migrator";
           jobShellScript = pkgs.writeShellScript "ats-task-migrator" ''
             authm refresh --headless || { logger -t authm "Authm refresh UNSUCCESSFUL"; >&2 echo "authm refresh error!"; exit 1; }
@@ -284,6 +295,7 @@ in
         anixpkgs.providence-tasker
         anixpkgs.daily_tactical_server
         anixpkgs.surveys_report
+        anixpkgs.disciple
       ];
     };
     machines.claude = {

--- a/pkgs/python-packages/flasks/disciple/default.nix
+++ b/pkgs/python-packages/flasks/disciple/default.nix
@@ -40,9 +40,11 @@ buildPythonPackage rec {
       groups consecutive Christ-reference verses with surrounding context,
       and provides a study interface for annotating and tagging passages.
 
-      Includes the `disciple-report` CLI, which reports study activity since
-      its last invocation to the tactical server's "Spiritual reflection"
-      survey question (1 processed group = partial credit, 2+ = full credit).
+      Includes the `disciple-report` CLI, which reports study activity for a
+      given local calendar day (yesterday by default, attributed by each
+      group's processed_at timestamp) to the tactical server's "Spiritual
+      reflection" survey question (1 processed group = partial credit,
+      2+ = full credit). Stateless and safe to re-run.
     '';
     autoGenUsageCmd = "--help";
   };

--- a/pkgs/python-packages/flasks/disciple/default.nix
+++ b/pkgs/python-packages/flasks/disciple/default.nix
@@ -3,6 +3,8 @@
   setuptools,
   flask,
   requests,
+  aapis-py,
+  grpcio,
   python,
   pkg-src,
 }:
@@ -27,6 +29,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     flask
     requests
+    aapis-py
+    grpcio
   ];
   meta = {
     description = "A Book of Mormon Christ-reference study tool.";
@@ -35,6 +39,10 @@ buildPythonPackage rec {
       reference Jesus Christ. Ingests all verses from the nephi.org API,
       groups consecutive Christ-reference verses with surrounding context,
       and provides a study interface for annotating and tagging passages.
+
+      Includes the `disciple-report` CLI, which reports study activity since
+      its last invocation to the tactical server's "Spiritual reflection"
+      survey question (1 processed group = partial credit, 2+ = full credit).
     '';
     autoGenUsageCmd = "--help";
   };


### PR DESCRIPTION
Adds a daily 05:00 ATS job (`ats-disciple-report`, `Persistent = true`) that reports scripture study activity from the disciple app to the tactical server's "Presence and Reflection" / "Spiritual reflection" survey question: 1 verse group processed yesterday = partial credit, 2+ = full credit, 0 = no credit. Attribution is by each group's `processed_at` local calendar day, computed statelessly on each run.

Changes:
- `pkgs/python-packages/flasks/disciple/default.nix`: add `aapis-py` + `grpcio` for the new `disciple-report` CLI (source in goromal/flasks#1)
- `pkgs/nixos/profiles/ats.nix`: new `ats-disciple-report` timed job; `anixpkgs.disciple` added to `extraOrchestratorPackages`
- `flake.lock`: flasks pinned to the dev branch commit — after goromal/flasks#1 merges, re-lock to the master commit (`nix flake update flasks`)

Verified on ats via local anix-upgrade: timer active (next fire 05:00), `disciple-report` on orchestratord's PATH, dry-runs against the live DB produce correct per-day credit, and a real gRPC submission landed in tacticald's `survey_results`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)