### PR TITLE
wormhole packaging + cozy prompt library deployment

### DIFF
--- a/changes/pr-585.md
+++ b/changes/pr-585.md
@@ -1,0 +1,1 @@
+wormhole packaging + cozy prompt library deployment

--- a/flake.lock
+++ b/flake.lock
@@ -276,15 +276,16 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1783784217,
-        "narHash": "sha256-lbWNExum6ow+7xrwPk+PdevnjlZ3N/8CcD2UYrfGWno=",
+        "lastModified": 1783881134,
+        "narHash": "sha256-HokHopmEt/NXK+obUc4fV2Z/MG9VZgSzuqdcKLWVeAY=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "00d758eba40e9d7f6037829c531dc7d3505ce21b",
+        "rev": "e95e163ecb3a6dfe8e46cc111fc7d2e027657b62",
         "type": "github"
       },
       "original": {
         "owner": "goromal",
+        "ref": "cozy-prompt-library",
         "repo": "flasks",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1783881134,
-        "narHash": "sha256-HokHopmEt/NXK+obUc4fV2Z/MG9VZgSzuqdcKLWVeAY=",
+        "lastModified": 1783887336,
+        "narHash": "sha256-kFKedsA44m/jR6+vl2jb7ovWQYEd8x0nIhqBAxGofX4=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "e95e163ecb3a6dfe8e46cc111fc7d2e027657b62",
+        "rev": "9fdf3c06e5af7b739193e4f75329f75c2f3cd1bf",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,16 +276,15 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1783887336,
-        "narHash": "sha256-kFKedsA44m/jR6+vl2jb7ovWQYEd8x0nIhqBAxGofX4=",
+        "lastModified": 1783950798,
+        "narHash": "sha256-5xxNBKnnsQwiSXXgrAfzEFow/+mT8dWwLsf19AqpKy8=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "9fdf3c06e5af7b739193e4f75329f75c2f3cd1bf",
+        "rev": "3a1fc3b6f8913a8cfe817e679a904586e28f4a55",
         "type": "github"
       },
       "original": {
         "owner": "goromal",
-        "ref": "cozy-prompt-library",
         "repo": "flasks",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
     find_rotational_conventions.url = "git+https://gist.github.com/fb15f44150ca4e0951acaee443f72d3e";
     find_rotational_conventions.flake = false;
 
-    flasks.url = "github:goromal/flasks";
+    flasks.url = "github:goromal/flasks/cozy-prompt-library";
     flasks.flake = false;
 
     geometry.url = "github:goromal/geometry";

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
     find_rotational_conventions.url = "git+https://gist.github.com/fb15f44150ca4e0951acaee443f72d3e";
     find_rotational_conventions.flake = false;
 
-    flasks.url = "github:goromal/flasks/cozy-prompt-library";
+    flasks.url = "github:goromal/flasks";
     flasks.flake = false;
 
     geometry.url = "github:goromal/geometry";

--- a/index.json
+++ b/index.json
@@ -424,6 +424,11 @@
                 "attr": "cozy",
                 "ci": true,
                 "docs": true
+            },
+            {
+                "attr": "wormhole",
+                "ci": true,
+                "docs": false
             }
         ],
         "bash": [

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -359,6 +359,9 @@ let
               intake_ui = addDoc (
                 pySelf.callPackage ./python-packages/flasks/intake_ui { pkg-src = flakeInputs.flasks; }
               );
+              wormhole = addDoc (
+                pySelf.callPackage ./python-packages/flasks/wormhole { pkg-src = flakeInputs.flasks; }
+              );
               cozy = addDoc (pySelf.callPackage ./python-packages/flasks/cozy { pkg-src = flakeInputs.flasks; });
               vdlserver = addDoc (
                 pySelf.callPackage ./python-packages/flasks/videodl {
@@ -473,6 +476,7 @@ rec {
   self-tester-app = final.python313.pkgs.self-tester-app;
   tasks_ui = final.python313.pkgs.tasks_ui;
   intake_ui = final.python313.pkgs.intake_ui;
+  wormhole = final.python313.pkgs.wormhole;
   cozy = final.python313.pkgs.cozy;
   vdlserver = final.python313.pkgs.vdlserver;
   easy-google-auth = final.python313.pkgs.easy-google-auth;

--- a/pkgs/nixos/modules/comfyui/module.nix
+++ b/pkgs/nixos/modules/comfyui/module.nix
@@ -115,6 +115,11 @@ in
         default = "/data/andrew/secrets/flask/cozy.json";
         description = "Path to JSON file with secret_key and password_hash";
       };
+      promptDbDir = lib.mkOption {
+        type = lib.types.str;
+        default = "${cfg.cozy.stateDir}/prompts";
+        description = "Directory of saved prompt .txt files (the default local prompt database)";
+      };
     };
   };
 
@@ -213,6 +218,7 @@ in
         ];
         systemd.tmpfiles.rules = [
           "d ${cfg.cozy.stateDir} 0755 andrew dev -"
+          "d ${cfg.cozy.promptDbDir} 0755 andrew dev -"
         ];
         # Let the cozy UI (running as andrew) restart ComfyUI via its
         # "Restart ComfyUI" button. Narrowly scoped: only andrew, only
@@ -240,7 +246,7 @@ in
           ];
           serviceConfig = {
             Type = "simple";
-            ExecStart = "${cfg.cozy.package}/bin/cozy --port ${builtins.toString service-ports.cozy} --subdomain /cozy --comfyui-url http://127.0.0.1:${builtins.toString cfg.port} --state-dir ${cfg.cozy.stateDir} --workflow-dir ${cfg.cozy.workflowDir} --input-dir ${cfg.cozy.inputDir} --output-dir ${cfg.cozy.outputDir} --workflows ${lib.concatStringsSep "," cfg.cozy.workflows} --secrets-file ${cfg.cozy.secretsFile} --comfyui-restart-cmd '${pkgs.systemd}/bin/systemctl restart comfyui.service'";
+            ExecStart = "${cfg.cozy.package}/bin/cozy --port ${builtins.toString service-ports.cozy} --subdomain /cozy --comfyui-url http://127.0.0.1:${builtins.toString cfg.port} --state-dir ${cfg.cozy.stateDir} --workflow-dir ${cfg.cozy.workflowDir} --input-dir ${cfg.cozy.inputDir} --output-dir ${cfg.cozy.outputDir} --workflows ${lib.concatStringsSep "," cfg.cozy.workflows} --secrets-file ${cfg.cozy.secretsFile} --prompt-db-dir ${cfg.cozy.promptDbDir} --comfyui-restart-cmd '${pkgs.systemd}/bin/systemctl restart comfyui.service'";
             ReadWritePaths = [ cfg.cozy.stateDir ];
             WorkingDirectory = cfg.cozy.stateDir;
             Restart = "always";

--- a/pkgs/python-packages/flasks/cozy/default.nix
+++ b/pkgs/python-packages/flasks/cozy/default.nix
@@ -1,6 +1,7 @@
 {
   buildPythonPackage,
   setuptools,
+  pytestCheckHook,
   flask,
   flask-login,
   flask-wtf,
@@ -8,6 +9,7 @@
   werkzeug,
   requests,
   websocket-client,
+  wormhole,
   python,
   pkg-src,
 }:
@@ -35,7 +37,9 @@ buildPythonPackage rec {
     werkzeug
     requests
     websocket-client
+    wormhole
   ];
+  nativeCheckInputs = [ pytestCheckHook ];
   meta = {
     description = "One-pager UI for generating images with ComfyUI workflows.";
     longDescription = "";

--- a/pkgs/python-packages/flasks/wormhole/default.nix
+++ b/pkgs/python-packages/flasks/wormhole/default.nix
@@ -1,0 +1,23 @@
+{
+  buildPythonPackage,
+  setuptools,
+  pytestCheckHook,
+  pkg-src,
+}:
+buildPythonPackage rec {
+  pname = "wormhole";
+  version = "0.0.0";
+  pyproject = true;
+  build-system = [ setuptools ];
+  src = "${pkg-src}/wormhole";
+  nativeCheckInputs = [ pytestCheckHook ];
+  meta = {
+    description = "Local-or-remote (ssh) file operations library shared by the flasks UIs.";
+    longDescription = ''
+      Stdlib-only helpers for listing, reading, writing, and deleting files
+      either on the local filesystem or on a remote host over ssh (BatchMode,
+      argv-array subprocess calls, shlex-quoted remote paths). Consuming
+      services must have openssh on their PATH for remote operations.
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

Companion to goromal/flasks#2 (cozy prompt library + remote image browsing).

- **New python package `wormhole`** (`pkgs/python-packages/flasks/wormhole/`): stdlib-only ssh file-ops library from the flasks input; registered in the python overlay + top-level alias, `index.json` entry (`ci: true`, `docs: false` — library without CLI). Tests run at build time via `pytestCheckHook`.
- **cozy**: now depends on `wormhole` and runs its 61-test pytest suite at build time (`pytestCheckHook`, same pattern as rankserver).
- **comfyui module**: new `services.comfyui.cozy.promptDbDir` option (default `${stateDir}/prompts`) with tmpfiles provisioning, passed to cozy as `--prompt-db-dir` — the default local prompt database.
- **flake**: the `flasks` input is temporarily pinned to the `cozy-prompt-library` branch (lock at `e95e163`) so this PR builds against the companion changes. Revert the pin to the default branch (and re-lock) once goromal/flasks#2 merges.

No deployment yet. After both PRs merge and the pin is reverted, the usual lock-update + deploy applies the feature, followed by the cross-machine smoke test (prompt save/load, remote DB browse, remote-image edit generation, flush cleanup).

## Test plan

- `nix build .#wormhole` → 13 passed
- `nix build .#cozy` (locked branch input, no override) → 61 passed, wormhole confirmed in runtime closure
- `module.nix` parses (`nix-instantiate --parse`); option/tmpfiles/flag follow existing cozy option patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)