### PR TITLE
Bump manif-geom-cpp (release/1.1), geometry, and manif-geom-rs

### DIFF
--- a/changes/pr-586.md
+++ b/changes/pr-586.md
@@ -1,0 +1,1 @@
+Bump manif-geom-cpp, geometry, and manif-geom-rs sources for geometry-stack Log and view-lifetime fixes.

--- a/changes/pr-586.md
+++ b/changes/pr-586.md
@@ -1,1 +1,1 @@
-Bump manif-geom-cpp, geometry, and manif-geom-rs sources for geometry-stack Log and view-lifetime fixes.
+Bump manif-geom-cpp (release/1.1), geometry, and manif-geom-rs

--- a/flake.lock
+++ b/flake.lock
@@ -292,11 +292,11 @@
     "geometry": {
       "flake": false,
       "locked": {
-        "lastModified": 1771609177,
-        "narHash": "sha256-tJgSBbC9lHSJdWy4HSW2POk5XZr2IIM+l0ABEaI+IDA=",
+        "lastModified": 1784000076,
+        "narHash": "sha256-Xe4Wxpce5U46NVW28ESpcdV4+JLWQtOh7ztEWJM85XM=",
         "owner": "goromal",
         "repo": "geometry",
-        "rev": "27564549b423069373d8e2324bc87d8c36d2b4bf",
+        "rev": "c1c675bf33563d888fe8975789e0bc3316229f52",
         "type": "github"
       },
       "original": {
@@ -391,16 +391,16 @@
     "manif-geom-cpp": {
       "flake": false,
       "locked": {
-        "lastModified": 1742189520,
-        "narHash": "sha256-0xF03b3GfZrJpjspc7MsJYiTl/mBrbVjVNl4c4iYrxQ=",
+        "lastModified": 1784000194,
+        "narHash": "sha256-+CaVpBx7yHgVOdTSm7fg93GzW9t9cm25BrNPIzyg6r4=",
         "owner": "goromal",
         "repo": "manif-geom-cpp",
-        "rev": "9bbb6c47c8d0b2d90a53e868cfea855354106bad",
+        "rev": "d976fb0d397d6a69656d0548fe33be50b583ed20",
         "type": "github"
       },
       "original": {
         "owner": "goromal",
-        "ref": "refs/tags/release/1.0",
+        "ref": "refs/tags/release/1.1",
         "repo": "manif-geom-cpp",
         "type": "github"
       }
@@ -408,11 +408,11 @@
     "manif-geom-rs": {
       "flake": false,
       "locked": {
-        "lastModified": 1781410162,
-        "narHash": "sha256-k3mBP7iY8PhXZHgKpaB/CCKWBjsVkwd05iQU9VSs1Ek=",
+        "lastModified": 1784000104,
+        "narHash": "sha256-NDwG/5hUujFxYevxxJ7hLhjSp24OeBH4+tWMMoN4eyY=",
         "owner": "goromal",
         "repo": "manif-geom-rs",
-        "rev": "2d64e5a38641d302239e1bb9dd30b2271e1e4bd3",
+        "rev": "310624d0643bd8c23551cd8fd74a96f08859f360",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
     makepyshell.url = "git+https://gist.github.com/e64b6bdc8a176c38092e9bde4c434d31";
     makepyshell.flake = false;
 
-    manif-geom-cpp.url = "github:goromal/manif-geom-cpp?ref=refs/tags/release/1.0";
+    manif-geom-cpp.url = "github:goromal/manif-geom-cpp?ref=refs/tags/release/1.1";
     manif-geom-cpp.flake = false;
 
     manif-geom-rs.url = "github:goromal/manif-geom-rs";

--- a/pkgs/cxx-packages/manif-geom-cpp/default.nix
+++ b/pkgs/cxx-packages/manif-geom-cpp/default.nix
@@ -7,7 +7,7 @@
 }:
 clangStdenv.mkDerivation {
   name = "manif-geom-cpp";
-  version = "1.0.0";
+  version = "1.1.0";
   src = pkg-src;
   nativeBuildInputs = [ cmake ];
   buildInputs = [


### PR DESCRIPTION
Bumps three source pins to pull in the recently merged geometry-stack fixes:

| Input | Old | New | Change |
|---|---|---|---|
| `manif-geom-cpp` | `release/1.0` (9bbb6c4) | **`release/1.1`** (d976fb0, new tag) | `SO3::Log` canonicalizes quaternion sign → geodesic tangents (goromal/manif-geom-cpp#18); package version 1.0.0 → 1.1.0 |
| `geometry` | 2756454 | c1c675b | `SE2/SE3 t()` numpy views keep owner alive (goromal/geometry#10) |
| `manif-geom-rs` | 2d64e5a | 310624d | same `log_map` canonicalization (goromal/manif-geom-rs#4) |

## Notes

- Cut the `release/1.1` tag on manif-geom-cpp since the Log change is behavioral and the flake pins release tags for this input (matching the `signals-cpp` convention).
- The `Exp(Log(·))` round trip now returns the canonical (`q_w ≥ 0`) quaternion representative. The `longDescription` example snippets in `pkgs/cxx-packages/manif-geom-cpp/default.nix` still show the old sign-sensitive comparisons; left as-is since they mirror the upstream README, but happy to refresh them here if preferred.

## Verification

Built locally with the updated lock — all three packages plus every in-tree dependent, with their test/check phases:

`manif-geom-cpp`, `geometry` (36 pytest), `manif-geom-rs` (cargo test), `ceres-factors`, `gnc`, `quad-sim-cpp`, `signals-cpp`, `pyceres_factors`, `pysignals`, `mesh-plotter`, `find_rotational_conventions`, `trafficsim` — all pass.

Also verified both fixes are live in the built `geometry` module: `Log(-q)` returns the geodesic, and `t()` views survive their temporaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)