### PR TITLE
cozy ETA estimation + multi-job queue

### DIFF
--- a/changes/pr-587.md
+++ b/changes/pr-587.md
@@ -1,0 +1,1 @@
+cozy ETA estimation + multi-job queue

--- a/changes/pr-cozy-eta-multijob.md
+++ b/changes/pr-cozy-eta-multijob.md
@@ -1,1 +1,0 @@
-cozy job ETA estimation + multi-job queue

--- a/changes/pr-cozy-eta-multijob.md
+++ b/changes/pr-cozy-eta-multijob.md
@@ -1,0 +1,1 @@
+cozy job ETA estimation + multi-job queue

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1784236552,
-        "narHash": "sha256-LMXIMZMr3hhhvURT5Ni5wZGXTSxs8pwTI4N1HULvOuw=",
+        "lastModified": 1784348812,
+        "narHash": "sha256-GEQdrYhWamCqtmJXR/CA3pDW5ws4tVZb13FxnjSbAdU=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "8fb940d180d1100d698fd41ae0ef1e0c8204e3a8",
+        "rev": "f9db72680f86e75eabc3962b368e3395ca4361cb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1784220334,
-        "narHash": "sha256-duVo61UrkDq8w3sreYabQWViIjs7wU2OPElz4cpvV3o=",
+        "lastModified": 1784236552,
+        "narHash": "sha256-LMXIMZMr3hhhvURT5Ni5wZGXTSxs8pwTI4N1HULvOuw=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "eabe29c5f0d7d9d2a8e63962a858c52409e74a54",
+        "rev": "8fb940d180d1100d698fd41ae0ef1e0c8204e3a8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1784214664,
-        "narHash": "sha256-GQcEMr3+XBeh/jfv6BvsyZQ9RHzL16MFYlZ0DF4TzTg=",
+        "lastModified": 1783950798,
+        "narHash": "sha256-5xxNBKnnsQwiSXXgrAfzEFow/+mT8dWwLsf19AqpKy8=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "5103d606036df9e57988caa4e62da4b610a425bc",
+        "rev": "3a1fc3b6f8913a8cfe817e679a904586e28f4a55",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1783950798,
-        "narHash": "sha256-5xxNBKnnsQwiSXXgrAfzEFow/+mT8dWwLsf19AqpKy8=",
+        "lastModified": 1784220334,
+        "narHash": "sha256-duVo61UrkDq8w3sreYabQWViIjs7wU2OPElz4cpvV3o=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "3a1fc3b6f8913a8cfe817e679a904586e28f4a55",
+        "rev": "eabe29c5f0d7d9d2a8e63962a858c52409e74a54",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1783950798,
-        "narHash": "sha256-5xxNBKnnsQwiSXXgrAfzEFow/+mT8dWwLsf19AqpKy8=",
+        "lastModified": 1784214664,
+        "narHash": "sha256-GQcEMr3+XBeh/jfv6BvsyZQ9RHzL16MFYlZ0DF4TzTg=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "3a1fc3b6f8913a8cfe817e679a904586e28f4a55",
+        "rev": "5103d606036df9e57988caa4e62da4b610a425bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Changelog entry for the cozy job-ETA + multi-job-queue feature (companion to goromal/flasks#3).

## Deployment note
- No NixOS module change needed: per-job images (`stateDir/queue/`) and `history.jsonl` already fall under the cozy service's `ReadWritePaths = [ stateDir ]` and the stateDir tmpfiles rule; no new Python deps; the 30 s gap is a new `--rest-gap` CLI flag defaulting to 30 (no module wiring required).
- To roll out, bump the `flasks` flake input to the merged goromal/flasks#3 commit, then rebuild.

## Test Plan
- [x] `nix build .#cozy` after the flasks input is bumped (runs the package's pytest check phase, which now covers the new modules)