### PR TITLE
flasks: stampserver dir-picker nav button + restamp auto-play UI

### DIFF
--- a/changes/pr-588.md
+++ b/changes/pr-588.md
@@ -1,0 +1,1 @@
+flasks: stampserver dir-picker nav button + restamp auto-play UI

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1784348812,
-        "narHash": "sha256-GEQdrYhWamCqtmJXR/CA3pDW5ws4tVZb13FxnjSbAdU=",
+        "lastModified": 1784351642,
+        "narHash": "sha256-t1FsJHJy1IvAHCPPy8IN9RFp+2U13tyBDq60Tk8vaRo=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "f9db72680f86e75eabc3962b368e3395ca4361cb",
+        "rev": "660bdb91fe244cf76feb88850f9ebc37ef14e697",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1784351642,
-        "narHash": "sha256-t1FsJHJy1IvAHCPPy8IN9RFp+2U13tyBDq60Tk8vaRo=",
+        "lastModified": 1784348812,
+        "narHash": "sha256-GEQdrYhWamCqtmJXR/CA3pDW5ws4tVZb13FxnjSbAdU=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "660bdb91fe244cf76feb88850f9ebc37ef14e697",
+        "rev": "f9db72680f86e75eabc3962b368e3395ca4361cb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1784348812,
-        "narHash": "sha256-GEQdrYhWamCqtmJXR/CA3pDW5ws4tVZb13FxnjSbAdU=",
+        "lastModified": 1784352344,
+        "narHash": "sha256-t1FsJHJy1IvAHCPPy8IN9RFp+2U13tyBDq60Tk8vaRo=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "f9db72680f86e75eabc3962b368e3395ca4361cb",
+        "rev": "d3e840213e335191850d11b732d436b754423be1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Bumps the `flasks` flake input to pull the updated stampserver UI:

- **Directory picker button** in the stampserver top bar (mirrors rankserver), reaching the existing `/zzz` stampables-config page.
- **Auto-play toggle** in the restamp UI: MP4s play through, images linger 10s, then advance.

Depends on **goromal/flasks#4**. The `flasks` input is temporarily pinned to `goromal/flasks@660bdb9` (the `patch/s` commit); re-lock to flasks `master` once #4 merges.

## Testing
Deployed locally via the anix-upgrade API (`local: true`) — run succeeded (`returncode 0`), `stampserver.service` active on the rebuilt package, and the deployed template contains the new nav link and auto-play script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)