### PR TITLE
[indi-harness] S1 SITL trajectory harness + stock-controller baseline env

### DIFF
--- a/changes/pr-589.md
+++ b/changes/pr-589.md
@@ -1,0 +1,1 @@
+[indi-harness] S1 SITL trajectory harness + stock-controller baseline env

--- a/flake.lock
+++ b/flake.lock
@@ -337,6 +337,22 @@
         "type": "github"
       }
     },
+    "indi-harness": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784424531,
+        "narHash": "sha256-1Ro5tLFbfVxz16ObMXHUwQ+PXEVjlXQbicV0J+Hs1SU=",
+        "owner": "goromal",
+        "repo": "indi-harness",
+        "rev": "61bc4963327833b7fed08cdf100c53fcec838c42",
+        "type": "github"
+      },
+      "original": {
+        "owner": "goromal",
+        "repo": "indi-harness",
+        "type": "github"
+      }
+    },
     "jetpack-nixos": {
       "inputs": {
         "cuda-legacy": "cuda-legacy",
@@ -888,6 +904,7 @@
         "geometry": "geometry",
         "gmail-parser": "gmail-parser",
         "gnc": "gnc",
+        "indi-harness": "indi-harness",
         "jetpack-nixos": "jetpack-nixos",
         "jetson-stats": "jetson-stats",
         "makepyshell": "makepyshell",

--- a/flake.lock
+++ b/flake.lock
@@ -340,11 +340,11 @@
     "indi-harness": {
       "flake": false,
       "locked": {
-        "lastModified": 1784424531,
-        "narHash": "sha256-1Ro5tLFbfVxz16ObMXHUwQ+PXEVjlXQbicV0J+Hs1SU=",
+        "lastModified": 1784447876,
+        "narHash": "sha256-xLxU8Q0O5iukCITJuQnFZzNKxyewcKfJ5sdZT3n3NAE=",
         "owner": "goromal",
         "repo": "indi-harness",
-        "rev": "61bc4963327833b7fed08cdf100c53fcec838c42",
+        "rev": "0e936977a1504d74b29d7d1ba43d9f99737572c3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,9 @@
     mavlog-utils.url = "github:goromal/mavlog-utils";
     mavlog-utils.flake = false;
 
+    indi-harness.url = "github:goromal/indi-harness";
+    indi-harness.flake = false;
+
     mesh-plotter.url = "github:goromal/mesh-plotter";
     mesh-plotter.flake = false;
 

--- a/index.json
+++ b/index.json
@@ -146,6 +146,11 @@
                 "docs": false
             },
             {
+                "attr": "indi-harness",
+                "ci": true,
+                "docs": false
+            },
+            {
                 "attr": "pyceres",
                 "ci": true,
                 "docs": true

--- a/pkgs/cxx-packages/arducopter/sitl-module.nix
+++ b/pkgs/cxx-packages/arducopter/sitl-module.nix
@@ -32,14 +32,19 @@ let
       chown ${cfg.user}:${cfg.group} "$ENV_FILE"
     fi
   '';
-  paramsFile = pkgs.writeText "sitl-params.parm" ((lib.concatStringsSep "\n" cfg.parameters) + "\n");
+  paramsFile = pkgs.writeText "sitl-params.parm" (
+    (lib.optionalString (cfg.baseDefaultsFile != null) (builtins.readFile cfg.baseDefaultsFile + "\n"))
+    + (lib.concatStringsSep "\n" cfg.parameters)
+    + "\n"
+  );
+  haveDefaults = cfg.baseDefaultsFile != null || cfg.parameters != [ ];
   simExecScript = pkgs.writeShellScriptBin "sim-exec-start" ''
     source "${cfg.rootDir}/${simEnvFileName}"
     exec ${cfg.package}/bin/arducopter \
       --model=${cfg.platform} \
       --home="$LAT,$LON,$ALT,$HDG" \
       --config=undulation:$UND \
-      -S -I 0 ${lib.optionalString (cfg.parameters != [ ]) "\\\n      --defaults ${paramsFile}"}
+      -S -I 0 ${lib.optionalString haveDefaults "\\\n      --defaults ${paramsFile}"}
   '';
 in
 {
@@ -65,6 +70,16 @@ in
       type = lib.types.str;
       description = "Vehicle platform/frame type passed to the SITL --model flag (default: quad)";
       default = "quad";
+    };
+    baseDefaultsFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Base parameter defaults file prepended to `parameters` (e.g. ArduPilot's
+        Tools/autotest/default_params/copter.parm, which carries the frame class
+        and sensor-calibration values SITL needs to pass prearm checks). Entries
+        in `parameters` override it (last assignment wins).
+      '';
     };
     parameters = lib.mkOption {
       type = lib.types.listOf lib.types.str;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -269,6 +269,11 @@ let
                   pkg-src = flakeInputs.mavlog-utils;
                 }
               );
+              indi-harness = addDoc (
+                pySelf.callPackage ./python-packages/indi-harness {
+                  pkg-src = flakeInputs.indi-harness;
+                }
+              );
               mesh-plotter = addDoc (
                 pySelf.callPackage ./python-packages/mesh-plotter {
                   pkg-src = flakeInputs.mesh-plotter;
@@ -440,6 +445,7 @@ rec {
   surveys_report = final.python313.pkgs.surveys_report;
   makepyshell = final.python313.pkgs.makepyshell;
   mavlog-utils = final.python313.pkgs.mavlog-utils;
+  indi-harness = final.python313.pkgs.indi-harness;
   fqt = final.python313.pkgs.fqt;
   ichabod = final.python313.pkgs.ichabod;
   norbert = final.python313.pkgs.norbert;

--- a/pkgs/nixos/drone-base.nix
+++ b/pkgs/nixos/drone-base.nix
@@ -172,7 +172,9 @@ in
           iotop
           iperf
           iftop
-          python3
+          # python with the S1 trajectory harness replaces the bare python3
+          # (avoids a bin/python3 collision between two interpreters).
+          (anixpkgs.python313.withPackages (ps: [ ps.indi-harness ]))
           xsel
           htop
           jq
@@ -271,6 +273,11 @@ in
       # XRCE-DDS agent over UDP. These match the Ardupilot defaults, but are
       # pinned here so upstream default changes can't silently break the
       # ROS2 bridge.
+      # Upstream SITL copter defaults (frame class/type, INS calibration, RC
+      # ranges): without them a fresh eeprom fails prearm ("Motors: Check
+      # frame class and type", "3D Accel calibration needed") and the vehicle
+      # can never arm — sim_vehicle.py always launches SITL with this file.
+      baseDefaultsFile = "${anixpkgs.arducopter.sitl.src}/Tools/autotest/default_params/copter.parm";
       parameters = [
         "DDS_ENABLE 1"
         "DDS_DOMAIN_ID 0"

--- a/pkgs/nixos/modules/cudaNode/module.nix
+++ b/pkgs/nixos/modules/cudaNode/module.nix
@@ -37,6 +37,7 @@ in
           pyceres
           pyceres_factors
           mesh-plotter
+          indi-harness
           find_rotational_conventions
         ];
     };

--- a/pkgs/nixos/sitl-envs/s1-baseline.nix
+++ b/pkgs/nixos/sitl-envs/s1-baseline.nix
@@ -1,0 +1,101 @@
+# Headless S1 baseline: boots the SITL stack and flies the stock-controller
+# trajectory battery, exporting RMSE artifacts (design doc S1 exit).
+# Run: nix-build pkgs/nixos/sitl-envs/s1-baseline.nix
+with import ../dependencies.nix;
+let
+  pkgs = (
+    import (fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-${nixos-version}") {
+      config = { };
+      overlays = [ ];
+    }
+  );
+in
+pkgs.testers.runNixOSTest {
+  name = "s1-baseline";
+  nodes = {
+    drone =
+      { config, pkgs, ... }:
+      {
+        imports = [ ../configurations/drone-obc-sitl.nix ];
+        virtualisation.cores = 4;
+        virtualisation.memorySize = 8192;
+        virtualisation.diskSize = 8192;
+        # Diagnostic probe: prints prearm STATUSTEXT / ACKs / key params so
+        # arming failures in the headless battery are explainable from logs.
+        environment.etc."s1-arm-probe.py".text = ''
+          import time
+          from pymavlink import mavutil
+
+          c = mavutil.mavlink_connection("tcp:127.0.0.1:5790")
+          c.wait_heartbeat(timeout=120)
+          print(f"probe: heartbeat sys={c.target_system} comp={c.target_component}", flush=True)
+          c.mav.request_data_stream_send(c.target_system, c.target_component,
+              mavutil.mavlink.MAV_DATA_STREAM_ALL, 4, 1)
+          for p in (b"ARMING_CHECK", b"FS_THR_ENABLE", b"SIM_SPEEDUP", b"GPS_TYPE"):
+              c.mav.param_request_read_send(c.target_system, c.target_component, p, -1)
+          t0 = time.time()
+          arms = 0
+          seen_rc = seen_fix = None
+          while time.time() - t0 < 90:
+              if (arms == 0 and time.time() - t0 > 10) or (arms == 1 and time.time() - t0 > 60):
+                  c.mav.command_long_send(c.target_system, c.target_component,
+                      mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM, 0, 1, 0, 0, 0, 0, 0, 0)
+                  arms += 1
+                  print(f"probe: ARM attempt {arms} at t={time.time()-t0:.0f}s", flush=True)
+              m = c.recv_match(type=["STATUSTEXT", "COMMAND_ACK", "PARAM_VALUE",
+                                     "RC_CHANNELS", "GPS_RAW_INT", "HEARTBEAT"],
+                               blocking=True, timeout=2)
+              if m is None:
+                  continue
+              k = m.get_type()
+              if k == "STATUSTEXT":
+                  print(f"probe: STATUSTEXT sev={m.severity} {m.text}", flush=True)
+              elif k == "COMMAND_ACK":
+                  print(f"probe: ACK cmd={m.command} result={m.result}", flush=True)
+              elif k == "PARAM_VALUE":
+                  print(f"probe: PARAM {m.param_id} = {m.param_value}", flush=True)
+              elif k == "RC_CHANNELS" and seen_rc is None:
+                  seen_rc = (m.chan1_raw, m.chan2_raw, m.chan3_raw, m.chan4_raw)
+                  print(f"probe: RC_CHANNELS 1-4 = {seen_rc}", flush=True)
+              elif k == "GPS_RAW_INT" and m.fix_type != seen_fix:
+                  seen_fix = m.fix_type
+                  print(f"probe: GPS fix_type -> {m.fix_type} at t={time.time()-t0:.0f}s", flush=True)
+              elif k == "HEARTBEAT" and (m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED):
+                  print(f"probe: ARMED at t={time.time()-t0:.0f}s", flush=True)
+                  c.mav.command_long_send(c.target_system, c.target_component,
+                      mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM, 0, 0, 0, 21196, 0, 0, 0, 0)
+                  break
+          print("probe: done", flush=True)
+        '';
+      };
+  };
+  testScript =
+    { nodes, ... }:
+    ''
+      machines[0].wait_for_unit("default.target")
+      machines[0].wait_for_unit("ardusitl.service")
+      machines[0].wait_for_unit("ardurouter.service")
+      machines[0].wait_until_succeeds("ss -tn state established '( dport = :5760 )' | grep -q 5760", timeout=120)
+      machines[0].wait_until_succeeds("ss -tln '( sport = :5790 )' | grep -q 5790", timeout=60)
+      # EKF needs sim GPS lock before arming; the battery's arm() retries, but
+      # give the stack a generous head start on loaded runners.
+      machines[0].succeed("python3 -c 'import indi_harness.sitl.baseline'")
+      print(machines[0].execute("timeout 180 python3 /etc/s1-arm-probe.py 2>&1")[1])
+      try:
+          machines[0].succeed(
+              "timeout 3600 python3 -m indi_harness.sitl.baseline"
+              " --url tcp:127.0.0.1:5790"
+              " --logs-dir /data/drone/ardusitl/logs"
+              " --out /tmp/s1_baseline >&2"
+          )
+      except Exception:
+          print("=== ardusitl journal (arm/EKF/GPS lines) ===")
+          print(machines[0].execute("journalctl -u ardusitl --no-pager | grep -iE 'prearm|arm|ekf|gps|home' | tail -60")[1])
+          print("=== log dir ===")
+          print(machines[0].execute("find /data/drone -name '*.BIN' 2>/dev/null; ls -la /data/drone/ardusitl 2>/dev/null")[1])
+          raise
+      machines[0].succeed("test -s /tmp/s1_baseline/s1_baseline.json")
+      machines[0].copy_from_vm("/tmp/s1_baseline/s1_baseline.json", "")
+      print(machines[0].succeed("cat /tmp/s1_baseline/s1_baseline.json"))
+    '';
+}

--- a/pkgs/python-packages/indi-harness/default.nix
+++ b/pkgs/python-packages/indi-harness/default.nix
@@ -1,0 +1,28 @@
+{
+  buildPythonPackage,
+  setuptools,
+  numpy,
+  pyyaml,
+  pymavlink,
+  pytestCheckHook,
+  pkg-src,
+}:
+buildPythonPackage rec {
+  pname = "indi_harness";
+  version = "0.1.0";
+  pyproject = true;
+  build-system = [ setuptools ];
+  propagatedBuildInputs = [
+    numpy
+    pyyaml
+    pymavlink
+  ];
+  nativeCheckInputs = [ pytestCheckHook ];
+  src = pkg-src;
+  meta = {
+    description = "Quaternion INDI prototype and SITL trajectory harness (S0/S1 of the ArduPilot INDI plan).";
+    longDescription = ''
+      [Repository](https://github.com/goromal/indi-harness)
+    '';
+  };
+}


### PR DESCRIPTION
## Summary
- Package `indi-harness` (github:goromal/indi-harness) as a python package following the mavlog-utils pattern; the build's check phase runs its full 67-test pytest suite.
- New `pkgs/nixos/sitl-envs/s1-baseline.nix` headless VM test: boots the SITL stack, flies the 5-case S1 trajectory battery in GUIDED via MAVLink, and exports per-case EKF tracking-RMSE JSON scored from the `.BIN` dataflash (design-doc S1 exit; repeatability checked across two fresh VM runs).
- `services.ardupilot-sim` gains a `baseDefaultsFile` option, pointed at ArduPilot's own `Tools/autotest/default_params/copter.parm` — without those defaults (frame class/type, INS accel calibration) a fresh-eeprom SITL fails prearm and can never arm.
- Drone VM guest python and the launchpad Jupyter env (cudaNode module) both carry `indi-harness`.

## Test Plan
- [x] `nix build .#indi-harness` green (pytestCheckHook: 67 passed)
- [x] `nix-build pkgs/nixos/sitl-envs/s1-baseline.nix` green; exported JSON has 5 finite-RMSE cases
- [x] Two fresh VM runs agree per case within `max(0.15 m, 30%)` (`indi-harness scripts/compare_baselines.py` → exit 0)
- [x] Deployed locally to atorgesen-dell via anix-upgrade (`local: true`); launchpad unit env imports `indi_harness`

Merging this unblocks repinning launchpad's `.shell.nix` from the branch tarball to a release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)