### PR TITLE
stampserver: bump flasks pin for whitespace tool

### DIFF
--- a/changes/pr-593.md
+++ b/changes/pr-593.md
@@ -1,0 +1,1 @@
+stampserver: bump flasks pin for whitespace tool

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1784729017,
-        "narHash": "sha256-wjlbK6oHqwEKTeeEzy1d0y5tjVFpAvG3kcjGh2jB/18=",
+        "lastModified": 1784352344,
+        "narHash": "sha256-t1FsJHJy1IvAHCPPy8IN9RFp+2U13tyBDq60Tk8vaRo=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "e5a6b5ccc3be7a85cf5608c2fbe7dbce8327970c",
+        "rev": "d3e840213e335191850d11b732d436b754423be1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1784352344,
-        "narHash": "sha256-t1FsJHJy1IvAHCPPy8IN9RFp+2U13tyBDq60Tk8vaRo=",
+        "lastModified": 1784747418,
+        "narHash": "sha256-wjlbK6oHqwEKTeeEzy1d0y5tjVFpAvG3kcjGh2jB/18=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "d3e840213e335191850d11b732d436b754423be1",
+        "rev": "74d4f32f4ba863cb06bf15edbd07213ef4de1567",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1784352344,
-        "narHash": "sha256-t1FsJHJy1IvAHCPPy8IN9RFp+2U13tyBDq60Tk8vaRo=",
+        "lastModified": 1784729017,
+        "narHash": "sha256-wjlbK6oHqwEKTeeEzy1d0y5tjVFpAvG3kcjGh2jB/18=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "d3e840213e335191850d11b732d436b754423be1",
+        "rev": "e5a6b5ccc3be7a85cf5608c2fbe7dbce8327970c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `flasks` flake input to the branch commit that adds the stampserver **Add Whitespace** (image padding) tool.

Depends on goromal/flasks#5.

**Temporary pin** (same pattern as #588): `flake.lock` points the `flasks` input at the `dev/wspace` commit `e5a6b5c`. After flasks#5 merges, re-lock the input back to `master`:

```
nix flake lock --override-input flasks github:goromal/flasks/<merged-sha>
```