### PR TITLE
build(flasks): bump flasks input for stampserver video-trim preserve

### DIFF
--- a/changes/pr-604.md
+++ b/changes/pr-604.md
@@ -1,0 +1,1 @@
+build(flasks): bump flasks input for stampserver video-trim preserve

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1785610483,
-        "narHash": "sha256-qmSj8OGigkDG85lmyQzGOQiOAluATYgrgt0Lja8oPhg=",
+        "lastModified": 1785523324,
+        "narHash": "sha256-tuHr5p3SzNrLO8svsvvDIPUfaY/uiWgAszthHZc3HxQ=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "608a6a53c5c5af664fe9cd300532bf6d48611e3a",
+        "rev": "5abe6ab349b366a3d0a974c07693e3571ce3d510",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1785468119,
-        "narHash": "sha256-KABaBef9lBElrF9sWrwaofOwUn8v3gKBrFTMZuC7Ir0=",
+        "lastModified": 1785610483,
+        "narHash": "sha256-qmSj8OGigkDG85lmyQzGOQiOAluATYgrgt0Lja8oPhg=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "124ccc8bd70b723b516b3f18ee3338b04c7f08e4",
+        "rev": "608a6a53c5c5af664fe9cd300532bf6d48611e3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `flasks` flake input to pull in **goromal/flasks#11**, which makes stampserver video-clip trimming preserve the original by default (saving the trimmed result as a new collision-free `_trimmed` file), with a UI checkbox to opt into overwrite-in-place.

- `flake.lock`: flasks input `124ccc8…` → `608a6a5` (flasks `dev/stampe`).

Depends on flasks#11. After that merges, re-lock the flasks input to flasks `master` (`nix flake lock --update-input flasks`) before/at merge so this tracks the merged rev rather than the dev branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)