### PR TITLE
flake: bump flasks input for stampserver stamp-name support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1786250019,
-        "narHash": "sha256-B6X4AYwXzylvxZpeeokUR0MRVLe6N7b1MCIA5hZJ1Vg=",
+        "lastModified": 1786248589,
+        "narHash": "sha256-qmSj8OGigkDG85lmyQzGOQiOAluATYgrgt0Lja8oPhg=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "b757f2fb16087838bf82d243313544fb82f5e595",
+        "rev": "74c1a6ddba389b90ab9a52f10ee0b54fb0186317",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1785523324,
-        "narHash": "sha256-tuHr5p3SzNrLO8svsvvDIPUfaY/uiWgAszthHZc3HxQ=",
+        "lastModified": 1786250019,
+        "narHash": "sha256-B6X4AYwXzylvxZpeeokUR0MRVLe6N7b1MCIA5hZJ1Vg=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "5abe6ab349b366a3d0a974c07693e3571ce3d510",
+        "rev": "b757f2fb16087838bf82d243313544fb82f5e595",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps the `flasks` input to pick up the stampserver change that lets stamp names contain spaces and any standard keyboard character **except `.`** (the filename field delimiter) and `/` (a path separator). See the app-side PR for details: goromal/flasks#12.

This is a `flake.lock`-only change.

## Ordering / dependency

- Depends on **goromal/flasks#12** — merge that first.
- The lock currently pins the feature-branch commit `b757f2f`. After #12 merges, run `nix flake update flasks` to repoint the lock at the flasks **master** commit, then merge this PR.

## Verification

Built and deployed locally (`anix-upgrade --local`) on `atorgesen-dell`; the running `stampserver` service executes the newly-built package with the fix, and the flask test suite passes (12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)