### PR TITLE
goromail: route postfix mail by sender

### DIFF
--- a/changes/pr-610.md
+++ b/changes/pr-610.md
@@ -1,0 +1,1 @@
+goromail: route postfix mail by sender

--- a/flake.lock
+++ b/flake.lock
@@ -330,11 +330,11 @@
     "flasks": {
       "flake": false,
       "locked": {
-        "lastModified": 1786409828,
-        "narHash": "sha256-G27UYDpiwOIYUdXF3uqAd2XTqcpPRre2nM+hSgjrKy0=",
+        "lastModified": 1786595622,
+        "narHash": "sha256-gsg2WJ7Eblg+5KWh3PU3ok2UU1f3lv6nelGMRV3JIUE=",
         "owner": "goromal",
         "repo": "flasks",
-        "rev": "46da286471d1797a02a70f174b147850b4c60c53",
+        "rev": "12b6a76b8350b295ec081d16abd0b343086fb443",
         "type": "github"
       },
       "original": {

--- a/pkgs/python-packages/goromail/cli.py
+++ b/pkgs/python-packages/goromail/cli.py
@@ -4,7 +4,7 @@ import os
 import sys
 from email import policy
 from email.parser import BytesParser
-from email.utils import parsedate_to_datetime
+from email.utils import parsedate_to_datetime, parseaddr
 from colorama import Fore, Style
 from datetime import datetime
 from pathlib import Path
@@ -20,6 +20,12 @@ from aapis.tactical.v1 import tactical_pb2_grpc, tactical_pb2
 MAIL_EMAIL = "andrew.torgesen@gmail.com"
 TEXT_EMAIL = "6612105214@vzwpix.com"
 MAILDIR_PATH = "/var/mail/goromail"
+
+# Senders whose mail may only ever become a survey result -- never a Notion
+# block, whatever the body looks like. Domains match subdomains too.
+NUTRITION_SENDERS = ("loseit.com",)
+# Senders allowed to issue the full command set (journal, keywords, tasks, ITNS).
+OWNER_SENDERS = (MAIL_EMAIL, TEXT_EMAIL)
 
 
 class PostfixMessage:
@@ -51,6 +57,81 @@ class PostfixMessage:
 
     def moveToTrash(self):
         self.maildir.remove(self.key)
+
+
+def sender_matches(sender, patterns):
+    """True if the address in a From header matches any of `patterns`.
+
+    A pattern is either a full address ("a@b.com") or a bare domain
+    ("loseit.com"), which also covers its subdomains. Only the address is
+    matched, never the display name, so a From header of
+    `"andrew.torgesen@gmail.com" <spam@elsewhere.net>` will not match.
+    """
+    addr = parseaddr(sender or "")[1].lower()
+    if not addr:
+        return False
+    for pattern in patterns:
+        pattern = pattern.lower()
+        if addr == pattern or addr.endswith(f"@{pattern}") or addr.endswith(f".{pattern}"):
+            return True
+    return False
+
+
+def classify_sender(sender):
+    """Route a postfix message on its From header rather than its body.
+
+    "nutrition" -- may only produce a survey result; never reaches Notion.
+    "owner"     -- the full command set (journal, keywords, calories, tasks, ITNS).
+    "unknown"   -- anything else that reached the mailbox; left untouched.
+
+    Postfix accepts mail for the whole domain, so the catch-all ITNS branch is
+    reachable by any stranger unless senders are classified up front.
+    """
+    if sender_matches(sender, NUTRITION_SENDERS):
+        return "nutrition"
+    if sender_matches(sender, OWNER_SENDERS):
+        return "owner"
+    return "unknown"
+
+
+def handle_nutrition_message(msg, date, tactical_port, dry_run, log):
+    """Report a nutrition email as a survey result. Never writes to Notion.
+
+    Unparseable mail from a nutrition sender is logged and trashed rather than
+    falling through to another handler -- the underlying data still lives in
+    the source app, so there is nothing to recover from the email itself.
+    """
+    loseit = parse_loseit_email(msg.raw_text)
+    if loseit is None:
+        print(
+            Fore.YELLOW
+            + f"  Unparsed nutrition email from {date}; discarding"
+            + Style.RESET_ALL
+        )
+        log(f"Unparsed nutrition email from {date}; discarded")
+        if not dry_run:
+            msg.moveToTrash()
+        return False
+
+    summary_date, consumed, budget = loseit
+    summary_date = summary_date.replace(year=date.year)
+    nutrients = parse_loseit_nutrients(msg.raw_text)
+    level = eating_discipline_level(consumed, budget, nutrients)
+    surplus = consumed - budget
+    extra = ""
+    if nutrients is not None and consumed > 0:
+        fat_g, carb_g, protein_g, fat_pct = nutrients
+        coverage = (9 * fat_g + 4 * carb_g + 4 * protein_g) / consumed
+        extra = f", nutrient coverage {coverage:.0%}, fat {fat_pct:.1f}%"
+    print(
+        f"  Lose It! daily summary: {consumed} consumed / {budget} budget "
+        f"({'+' if surplus >= 0 else ''}{surplus} cal){extra} -> level {level}"
+    )
+    log(f"Lose It! summary for {summary_date.date()}: level {level}{extra}")
+    if not dry_run:
+        report_eating_discipline_to_tactical(tactical_port, summary_date, level)
+        msg.moveToTrash()
+    return True
 
 
 def process_keyword(
@@ -543,26 +624,25 @@ def postfix(ctx: click.Context, categories_csv, tactical_port, dry_run):
             text = msg.getText().strip()
             date = msg.getDate()
 
-            loseit = parse_loseit_email(msg.raw_text)
-            if loseit is not None:
-                summary_date, consumed, budget = loseit
-                summary_date = summary_date.replace(year=date.year)
-                nutrients = parse_loseit_nutrients(msg.raw_text)
-                level = eating_discipline_level(consumed, budget, nutrients)
-                surplus = consumed - budget
-                extra = ""
-                if nutrients is not None and consumed > 0:
-                    fat_g, carb_g, protein_g, fat_pct = nutrients
-                    coverage = (9 * fat_g + 4 * carb_g + 4 * protein_g) / consumed
-                    extra = f", nutrient coverage {coverage:.0%}, fat {fat_pct:.1f}%"
+            route = classify_sender(msg.sender)
+
+            if route == "nutrition":
+                handle_nutrition_message(msg, date, tactical_port, dry_run, log)
+                continue
+
+            if route == "unknown":
+                # Left in the maildir on purpose: silently deleting inbound mail
+                # loses real messages, and a growing queue is a visible signal.
                 print(
-                    f"  Lose It! daily summary: {consumed} consumed / {budget} budget "
-                    f"({'+' if surplus >= 0 else ''}{surplus} cal){extra} -> level {level}"
+                    Fore.YELLOW
+                    + f"  Ignoring mail from unrecognized sender: {msg.sender}"
+                    + Style.RESET_ALL
                 )
-                log(f"Lose It! summary for {summary_date.date()}: level {level}{extra}")
-                if not dry_run:
-                    report_eating_discipline_to_tactical(tactical_port, summary_date, level)
-                    msg.moveToTrash()
+                # The address goes to stdout (the diag log) but deliberately not
+                # into postfix.log, which ats-mailman greps for "notion" -- a
+                # sender like notion.so would otherwise trigger a spurious
+                # annotate-triage-pages run.
+                log("Ignored mail from unrecognized sender")
                 continue
 
             if text[:8].lower() == f"journal:":

--- a/pkgs/python-packages/goromail/tests/test_routing.py
+++ b/pkgs/python-packages/goromail/tests/test_routing.py
@@ -1,0 +1,194 @@
+from datetime import datetime
+
+import pytest
+
+from goromail import cli
+from goromail.cli import (
+    MAIL_EMAIL,
+    TEXT_EMAIL,
+    classify_sender,
+    handle_nutrition_message,
+    sender_matches,
+)
+
+
+# The address Lose It! actually sends daily summaries from.
+LOSEIT_SENDER = "donotreply@loseit.com"
+
+
+# --- sender_matches: address-only, domain-aware ---
+def test_matches_the_real_loseit_sender():
+    assert sender_matches(LOSEIT_SENDER, cli.NUTRITION_SENDERS)
+
+
+def test_matches_bare_address():
+    assert sender_matches("no-reply@loseit.com", ["loseit.com"])
+
+
+def test_matches_display_name_form():
+    assert sender_matches("Lose It! <no-reply@loseit.com>", ["loseit.com"])
+
+
+def test_matches_subdomain():
+    assert sender_matches("bounce@mail.loseit.com", ["loseit.com"])
+
+
+def test_matches_full_address_pattern():
+    assert sender_matches(f"Andrew <{MAIL_EMAIL}>", [MAIL_EMAIL])
+
+
+def test_is_case_insensitive():
+    assert sender_matches("No-Reply@LoseIt.COM", ["loseit.com"])
+
+
+def test_lookalike_domain_does_not_match():
+    # endswith(".loseit.com") must not be fooled by a domain merely ending in it
+    assert not sender_matches("spam@notloseit.com", ["loseit.com"])
+
+
+def test_display_name_spoof_does_not_match():
+    # The owner's address in the display name must not grant owner privileges
+    spoofed = f'"{MAIL_EMAIL}" <spam@elsewhere.net>'
+    assert not sender_matches(spoofed, [MAIL_EMAIL])
+
+
+def test_empty_and_none_senders():
+    assert not sender_matches("", ["loseit.com"])
+    assert not sender_matches(None, ["loseit.com"])
+    assert not sender_matches("not an address", ["loseit.com"])
+
+
+def test_empty_pattern_list():
+    assert not sender_matches("no-reply@loseit.com", [])
+
+
+# --- classify_sender: the routing table ---
+def test_nutrition_sender_routes_to_nutrition():
+    assert classify_sender(f"Lose It! <{LOSEIT_SENDER}>") == "nutrition"
+    assert classify_sender(LOSEIT_SENDER) == "nutrition"
+
+
+def test_owner_email_routes_to_owner():
+    assert classify_sender(MAIL_EMAIL) == "owner"
+
+
+def test_owner_text_routes_to_owner():
+    assert classify_sender(TEXT_EMAIL) == "owner"
+
+
+def test_stranger_routes_to_unknown():
+    assert classify_sender("someone@example.com") == "unknown"
+
+
+def test_missing_from_header_routes_to_unknown():
+    assert classify_sender(None) == "unknown"
+
+
+def test_nutrition_wins_over_owner():
+    # Should the owner ever also be a nutrition sender, nutrition must win --
+    # that is the branch that cannot reach Notion.
+    assert classify_sender(f"forwarder@{cli.NUTRITION_SENDERS[0]}") == "nutrition"
+
+
+# --- the guarantee: nutrition senders never reach the Notion branches ---
+@pytest.mark.parametrize(
+    "body",
+    [
+        "You haven't logged food in 3 days!",  # nag email
+        "<html>50% off Lose It! Premium</html>",  # promo
+        "Weekly Summary for Monday, March 3",  # wrong report type
+        "Daily calorie budget</td><td>2,000</td>",  # daily summary, drifted format
+        "",
+    ],
+)
+def test_unparseable_nutrition_mail_is_still_classified_nutrition(body):
+    """Body shape must not change the route. This is what keeps a nag email or a
+    format change from falling through to the catch-all ITNS Notion branch."""
+    assert classify_sender(LOSEIT_SENDER) == "nutrition"
+    assert cli.parse_loseit_email(body) is None  # would have hit the catch-all
+
+
+LOSEIT_HTML = """
+<html><body>
+<h1>Daily Summary for Monday, March 3</h1>
+<table>
+  <tr><td>Daily calorie budget</td><td align="right">2,000</td></tr>
+  <tr><td>Food calories consumed</td><td align="right">1,850</td></tr>
+</table>
+</body></html>
+"""
+
+
+class FakeMessage:
+    def __init__(self, raw_text, sender=f"Lose It! <{LOSEIT_SENDER}>"):
+        self.raw_text = raw_text
+        self.sender = sender
+        self.trashed = False
+
+    def moveToTrash(self):
+        self.trashed = True
+
+
+@pytest.fixture
+def logged():
+    return []
+
+
+@pytest.fixture
+def reported(monkeypatch):
+    """Capture survey submissions instead of dialing the tactical server."""
+    calls = []
+    monkeypatch.setattr(
+        cli,
+        "report_eating_discipline_to_tactical",
+        lambda port, date, level: calls.append((port, date, level)),
+    )
+    return calls
+
+
+DATE = datetime(2026, 3, 3, 9, 0)
+
+
+def test_parsed_summary_reports_and_trashes(logged, reported):
+    msg = FakeMessage(LOSEIT_HTML)
+    assert handle_nutrition_message(msg, DATE, 60060, False, logged.append) is True
+    # 1,850 consumed vs 2,000 budget -> surplus -150 -> full credit, no nutrients
+    assert reported == [(60060, datetime(2026, 3, 3), 2)]
+    assert msg.trashed
+
+
+def test_summary_year_comes_from_the_email_date(logged, reported):
+    # Lose It! omits the year, so it is taken from the message's own Date header
+    msg = FakeMessage(LOSEIT_HTML)
+    handle_nutrition_message(msg, datetime(2019, 3, 3), 60060, False, logged.append)
+    assert reported[0][1].year == 2019
+
+
+def test_unparseable_mail_is_trashed_without_reporting(logged, reported):
+    msg = FakeMessage("You haven't logged food in 3 days!")
+    assert handle_nutrition_message(msg, DATE, 60060, False, logged.append) is False
+    assert reported == []
+    assert msg.trashed
+    assert any("Unparsed nutrition email" in line for line in logged)
+
+
+def test_dry_run_neither_reports_nor_trashes(logged, reported):
+    msg = FakeMessage(LOSEIT_HTML)
+    assert handle_nutrition_message(msg, DATE, 60060, True, logged.append) is True
+    assert reported == []
+    assert not msg.trashed
+
+
+def test_dry_run_does_not_trash_unparseable_mail(logged, reported):
+    msg = FakeMessage("nothing parseable here")
+    assert handle_nutrition_message(msg, DATE, 60060, True, logged.append) is False
+    assert not msg.trashed
+
+
+def test_log_lines_do_not_trip_the_notion_grep(logged, reported):
+    """ats-mailman greps postfix.log for "notion" (case-insensitively) to decide
+    whether to re-run annotate-triage-pages. Nutrition lines must not match."""
+    handle_nutrition_message(FakeMessage(LOSEIT_HTML), DATE, 60060, False, logged.append)
+    handle_nutrition_message(FakeMessage("junk"), DATE, 60060, False, logged.append)
+    assert logged
+    assert not any("notion" in line.lower() for line in logged)


### PR DESCRIPTION
## Problem

The `postfix` path classified messages purely on body content. Anything unrecognized fell through to the catch-all ITNS branch and got appended to Notion:

```python
else:  # cli.py
    notion.append_blocks("3ea6f1aa...", truncated)
```

So Lose It! mail that wasn't an exact daily summary — a logging nag, a promo, or drifted HTML — landed in Notion as a wall of stripped markup. The daily-summary parse requires the literal string `Daily calorie budget` plus three regexes to all hit, so there was plenty of room to miss.

Root cause: the Gmail `bot` path has always filtered on sender (`fromSenders([TEXT_EMAIL, MAIL_EMAIL])`), but the postfix path lost that during the postfix migration and never regained it. `PostfixMessage` parsed `self.sender` and then never read it.

## Change

Classify on the `From` header before inspecting any body:

| route | senders | may produce |
|---|---|---|
| `nutrition` | `loseit.com` | survey result only — never Notion |
| `owner` | `MAIL_EMAIL`, `TEXT_EMAIL` | the full command set |
| `unknown` | anything else | nothing; logged and left in the maildir |

Nutrition senders `continue` unconditionally, so no body shape can reach the Notion branches. This also closes a side hole: postfix accepts mail for the whole `andrewtorgesen.com` domain, so any stranger could previously write straight to the ITNS page.

Sender matching uses `parseaddr`, so only the address counts, never the display name — `"andrew.torgesen@gmail.com" <spam@elsewhere.net>` does not get owner privileges. Domain patterns cover subdomains without matching lookalikes like `notloseit.com`.

## Decisions worth a second opinion

- **Unparseable nutrition mail is trashed** after logging. The data still lives in Lose It!, so there's nothing to recover from the email.
- **Unknown-sender mail is left in the maildir**, not trashed — silently deleting inbound mail is the worse failure. Cost: `ats-mailman` fires hourly while `new/` is non-empty, so accumulating junk means an hourly `Processed mail` syslog line. One-line change to trash it instead if that's too noisy.
- The ignored-sender log line **omits the address** because `ats-mailman` greps `postfix.log` for `notion` to decide whether to re-run `annotate-triage-pages`; mail from `notion.so` would otherwise trip it. The address still goes to stdout, i.e. the diag log.

`NUTRITION_SENDERS` stays at the domain rather than the exact `donotreply@loseit.com`, since a different local part for a different report type should still be nutrition-only.

## Testing

26 new tests in `tests/test_routing.py`; 49 pass under `nix build .#goromail`. Coverage includes lookalike domains, display-name spoofing, subdomains, missing `From` headers, year-from-message-date, dry-run inertness, and a guard that nutrition log lines never contain `notion`.

Mutation-checked for non-vacuity: forcing `classify_sender` to never return `nutrition` fails 7 tests.

Deployed locally on `ats` (`anix-upgrade --local`, rc 0) and driven end-to-end against the deployed binary with three fixtures staged in `cur/`:

```
Lose It! daily summary: 1850 consumed / 2000 budget (-150 cal) -> level 2
Unparsed nutrition email from 2026-08-11 08:05:00-07:00; discarding
Ignoring mail from unrecognized sender: Notion <team@notion.so>
```

The middle line is the reported bug: that nag email used to become a Notion block. Fixtures removed afterward; maildir left empty.

## Not included

The Gmail `bot` path is unchanged — it already filters to owner senders. Note that forwarding Lose It! mail into gbot from your own address would still hit that path's ITNS catch-all, since the `From` becomes yours. `postfix` also remains absent from `subCmds` in `default.nix`, so none of this appears in generated docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)